### PR TITLE
Scratch-Guiマージ時のScratch文言問題を修正しました

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -424,7 +424,7 @@ class MenuBar extends React.Component {
                                 src={profileIcon}
                             />
                             <span>
-                                {'scratch-cat' /* @todo username */}
+                                {'smalruby-hatti' /* @todo username */}
                             </span>
                             <img
                                 className={styles.dropdownCaretIcon}

--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="google" value="notranslate">
-    <link rel="shortcut icon" href="static/favicon.ico">
+    <link rel="shortcut icon" href="static/title.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <% if (htmlWebpackPlugin.options.sentryConfig) { %>
         <!-- Sentry error logging to help with finding bugs -->


### PR DESCRIPTION
# アイコンの修正
![screenshot from 2018-08-04 11-20-56](https://user-images.githubusercontent.com/23467008/43671625-92632af8-97d8-11e8-82c8-43da9490ab13.png)
# smalruby-hattiに修正
![screenshot from 2018-08-04 11-21-11](https://user-images.githubusercontent.com/23467008/43671626-928b0910-97d8-11e8-9ec1-fc2ff97f5413.png)


