### PR TITLE
プレビューのモーダルを削除しました

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -23,7 +23,6 @@ import CostumeLibrary from '../../containers/costume-library.jsx';
 import BackdropLibrary from '../../containers/backdrop-library.jsx';
 
 import Backpack from '../../containers/backpack.jsx';
-import PreviewModal from '../../containers/preview-modal.jsx';
 import ImportModal from '../../containers/import-modal.jsx';
 import WebGlModal from '../../containers/webgl-modal.jsx';
 import TipsLibrary from '../../containers/tips-library.jsx';
@@ -64,7 +63,6 @@ const GUIComponent = props => {
         costumeLibraryVisible,
         costumesTabVisible,
         enableCommunity,
-        hideIntro,
         importInfoVisible,
         intl,
         isPlayerOnly,
@@ -78,7 +76,6 @@ const GUIComponent = props => {
         onRequestCloseBackdropLibrary,
         onRequestCloseCostumeLibrary,
         onSeeCommunity,
-        previewInfoVisible,
         targetIsStage,
         soundsTabVisible,
         rubyTabVisible,
@@ -120,9 +117,6 @@ const GUIComponent = props => {
                 dir={isRtl ? 'rtl' : 'ltr'}
                 {...componentProps}
             >
-                {previewInfoVisible ? (
-                    <PreviewModal hideIntro={hideIntro} />
-                ) : null}
                 {loading ? (
                     <Loader />
                 ) : null}


### PR DESCRIPTION
before | after
---- | ----
![screenshot from 2018-09-04 12-51-52](https://user-images.githubusercontent.com/23467008/45009124-54fc8c00-b041-11e8-9c27-5233824a4a94.png) | ![screenshot from 2018-09-04 12-46-57](https://user-images.githubusercontent.com/23467008/45009131-5c239a00-b041-11e8-8d0b-00c13d4a1516.png)

#23 にも影響します。以下３つが必要なくなります。
`gui.smalruby3.previewInfo.welcome`
`gui.smalruby3.previewInfo.invitation`
`gui.smalruby3.previewInfo.betawelcome`

`previewInfoVisible`を`false`にすることも考えましたが、それだと何かの拍子にtrueになる可能性もあったので、表示させる部分を削除致しました。
他の部分でPreviewModalを使っている箇所はないので、こちらで大丈夫かと思われます。

実行直後一瞬プロジェクトを読み込んでいますという画面になりますが、一瞬のため特に問題はないかと思われます。

