### PR TITLE
rubyエディターをReadOnlyにしました

### DIFF
--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -7,6 +7,7 @@ import 'brace/theme/clouds';
 
 const RubyTab = ({rubyCode}) => (
     <AceEditor
+        readOnly
         editorProps={{$blockScrolling: true}}
         fontSize={16}
         height="inherit"
@@ -20,7 +21,6 @@ const RubyTab = ({rubyCode}) => (
         theme="clouds"
         value={rubyCode.rubyCode}
         width="100%"
-
     />
 );
 


### PR DESCRIPTION
画面は以下のものです。
![screenshot from 2018-09-04 13-09-45](https://user-images.githubusercontent.com/23467008/45009662-65facc80-b044-11e8-859a-90e39e75d13a.png)