### PR TITLE
TravisCIでのbuild時のprogressを出力しないように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - npm --production=false install
 - npm --production=false update
 script:
-- npm run build
+- npm run clean && $(npm bin)/webpack --colors --bail
 deploy:
 - provider: script
   on:


### PR DESCRIPTION
progressを出力するとログが乱れるため。
