### PR TITLE
eslintの無視対象を少し少なくして、さらにエラーを解消した

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,5 @@ node_modules/*
 build/*
 dist/*
 
-src/lib/ruby-generator/*
-src/lib/ruby-generator.js
+src/lib/ruby-generator/index.js
+src/lib/ruby-generator/generated.js

--- a/src/lib/ruby-generator/control.js
+++ b/src/lib/ruby-generator/control.js
@@ -6,7 +6,7 @@
 export default function (Blockly) {
     Blockly.Ruby.control_repeat = function (block) {
         const times = Blockly.Ruby.valueToCode(block, 'TIMES', Blockly.Ruby.ORDER_NONE) || '0';
-        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n'
+        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
 
         return `${times}.times do\n${branch}end\n`;
     };

--- a/src/lib/ruby-generator/math.js
+++ b/src/lib/ruby-generator/math.js
@@ -23,7 +23,6 @@ export default function (Blockly) {
         return [code, order];
     };
 
-    // TODO: math_whole_numberとmath_numberの違いはなにか?
     Blockly.Ruby.math_whole_number = function (block) {
         const code = parseFloat(block.getFieldValue('NUM'));
         const order = code < 0 ? Blockly.Ruby.ORDER_UNARY_SIGN : Blockly.Ruby.ORDER_ATOMIC;

--- a/src/lib/ruby-generator/motion.js
+++ b/src/lib/ruby-generator/motion.js
@@ -88,7 +88,7 @@ export default function (Blockly) {
         return `set_y(${y})\n`;
     };
 
-    Blockly.Ruby.motion_ifonedgebounce = function (block) {
+    Blockly.Ruby.motion_ifonedgebounce = function () {
         return 'if_on_edge_bounce()\n';
     };
 
@@ -97,15 +97,15 @@ export default function (Blockly) {
         return `set_rotation_style("${style}")\n`;
     };
 
-    Blockly.Ruby.motion_xposition = function (block) {
+    Blockly.Ruby.motion_xposition = function () {
         return ['x', Blockly.Ruby.ORDER_ATOMIC];
     };
 
-    Blockly.Ruby.motion_yposition = function (block) {
+    Blockly.Ruby.motion_yposition = function () {
         return ['y', Blockly.Ruby.ORDER_ATOMIC];
     };
 
-    Blockly.Ruby.motion_direction = function (block) {
+    Blockly.Ruby.motion_direction = function () {
         return ['direction', Blockly.Ruby.ORDER_ATOMIC];
     };
 


### PR DESCRIPTION
命令ブロックをRubyに変換するための定義はeslintの対象にした。
