### PR TITLE
Sound、Event、Controlの命令ブロックをRubyに変換できるようにしました。

### DIFF
--- a/src/lib/ruby-generator/control.js
+++ b/src/lib/ruby-generator/control.js
@@ -13,7 +13,7 @@ export default function (Blockly) {
         const times = Blockly.Ruby.valueToCode(block, 'TIMES', Blockly.Ruby.ORDER_NONE) || '0';
         const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
 
-        return `${times}.times do\n${branch}end\n`;
+        return `repeat(${times}) do\n${branch}end\n`;
     };
 
     Blockly.Ruby.control_forever = function (block) {
@@ -45,14 +45,14 @@ export default function (Blockly) {
         return `until ${operator}\n${branch}end\n`;
     };
 
-    // TODO 値を取得方法がわからない
-    Blockly.Ruby.control_stop = function () {
-        return '# wip: control_stop\n';
+    Blockly.Ruby.control_stop = function (block) {
+        const target = block.getFieldValue('STOP_OPTION') || null;
+        return `stop("${target}")\n`;
     };
 
     Blockly.Ruby.control_start_as_clone = function (block) {
         Blockly.Ruby.targetEventBlock = block;
-        return `${Blockly.Ruby.spriteName()}.when(:cloned) do\n`;
+        return `${Blockly.Ruby.spriteName()}.when(:start_as_a_clone) do\n`;
     };
 
     Blockly.Ruby.control_create_clone_of = function (block) {

--- a/src/lib/ruby-generator/control.js
+++ b/src/lib/ruby-generator/control.js
@@ -4,11 +4,69 @@
  * @return {Blockly} Blockly defined Ruby generator.
  */
 export default function (Blockly) {
+    Blockly.Ruby.control_wait = function (block) {
+        const secs = Blockly.Ruby.valueToCode(block, 'DURATION', Blockly.Ruby.ORDER_NONE) || '0';
+        return `sleep(${secs})\n`;
+    };
+
     Blockly.Ruby.control_repeat = function (block) {
         const times = Blockly.Ruby.valueToCode(block, 'TIMES', Blockly.Ruby.ORDER_NONE) || '0';
         const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
 
         return `${times}.times do\n${branch}end\n`;
+    };
+
+    Blockly.Ruby.control_forever = function (block) {
+        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
+        return `forever do\n${branch}end\n`;
+    };
+
+    Blockly.Ruby.control_if = function (block) {
+        const operator = Blockly.Ruby.valueToCode(block, 'CONDITION', Blockly.Ruby.ORDER_NONE) || 'false';
+        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
+        return `if ${operator}\n${branch}end\n`;
+    };
+
+    Blockly.Ruby.control_if_else = function (block) {
+        const operator = Blockly.Ruby.valueToCode(block, 'CONDITION', Blockly.Ruby.ORDER_NONE) || 'false';
+        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
+        const branch2 = Blockly.Ruby.statementToCode(block, 'SUBSTACK2') || '\n';
+        return `if ${operator}\n${branch}else\n${branch2}end\n`;
+    };
+
+    Blockly.Ruby.control_wait_until = function (block) {
+        const operator = Blockly.Ruby.valueToCode(block, 'CONDITION', Blockly.Ruby.ORDER_NONE) || 'false';
+        return `wait until ${operator}\n`;
+    };
+
+    Blockly.Ruby.control_repeat_until = function (block) {
+        const operator = Blockly.Ruby.valueToCode(block, 'CONDITION', Blockly.Ruby.ORDER_NONE) || 'false';
+        const branch = Blockly.Ruby.statementToCode(block, 'SUBSTACK') || '\n';
+        return `until ${operator}\n${branch}end\n`;
+    };
+
+    // TODO 値を取得方法がわからない
+    Blockly.Ruby.control_stop = function () {
+        return '# wip: control_stop\n';
+    };
+
+    Blockly.Ruby.control_start_as_clone = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        return `${Blockly.Ruby.spriteName()}.when(:cloned) do\n`;
+    };
+
+    Blockly.Ruby.control_create_clone_of = function (block) {
+        const target = Blockly.Ruby.valueToCode(block, 'CLONE_OPTION', Blockly.Ruby.ORDER_NONE) || null;
+        return `create_clone("${target}")\n`;
+    };
+
+    Blockly.Ruby.control_create_clone_of_menu = function (block) {
+        const target = block.getFieldValue('CLONE_OPTION') || null;
+        return [target, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.control_delete_this_clone = function () {
+        return 'delete_this_clone\n';
     };
 
     return Blockly;

--- a/src/lib/ruby-generator/event.js
+++ b/src/lib/ruby-generator/event.js
@@ -33,20 +33,17 @@ export default function (Blockly) {
         return `${Blockly.Ruby.spriteName()}.when(:greater_than, "${lh}", ${rh})  do\n`;
     };
 
-    // TODO messageが文字化けするのを修正する
     Blockly.Ruby.event_whenbroadcastreceived = function (block) {
         Blockly.Ruby.targetEventBlock = block;
         const message = block.getFieldValue('BROADCAST_OPTION') || null;
         return `${Blockly.Ruby.spriteName()}.when(receive:, "${message}") do\n`;
     };
 
-    // TODO messageが文字化けするのを修正する
     Blockly.Ruby.event_broadcast = function (block) {
         const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
         return `broadcast("${message}")\n`;
     };
 
-    // TODO messageが文字化けするのを修正する
     Blockly.Ruby.event_broadcastandwait = function (block) {
         const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
         return `broadcast_and_wait("${message}")\n`;
@@ -61,7 +58,6 @@ export default function (Blockly) {
         Blockly.Ruby.targetEventBlock = block;
         return `Stage.when(:stage_clicked) do\n`;
     };
-
 
     return Blockly;
 }

--- a/src/lib/ruby-generator/event.js
+++ b/src/lib/ruby-generator/event.js
@@ -9,5 +9,59 @@ export default function (Blockly) {
         return `${Blockly.Ruby.spriteName()}.when(:flag_clicked) do\n`;
     };
 
+    Blockly.Ruby.event_whenthisspriteclicked = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        return `${Blockly.Ruby.spriteName()}.when(:click) do\n`;
+    };
+
+    Blockly.Ruby.event_whenkeypressed = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        const key = block.getFieldValue('KEY_OPTION') || null;
+        return `${Blockly.Ruby.spriteName()}.when(:key_pressed, "${key}") do\n`;
+    };
+
+    Blockly.Ruby.event_whenbackdropswitchesto = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        const backdrop = block.getFieldValue('BACKDROP') || null;
+        return `${Blockly.Ruby.spriteName()}.when(:backdrop_switches, "${backdrop}") do\n`;
+    };
+
+    Blockly.Ruby.event_whengreaterthan = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        const lh = block.getFieldValue('WHENGREATERTHANMENU') || null;
+        const rh = Blockly.Ruby.valueToCode(block, 'VALUE', Blockly.Ruby.ORDER_NONE) || '0';
+        return `${Blockly.Ruby.spriteName()}.when(:greater_than, "${lh}", ${rh})  do\n`;
+    };
+
+    // TODO messageが文字化けするのを修正する
+    Blockly.Ruby.event_whenbroadcastreceived = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        const message = block.getFieldValue('BROADCAST_OPTION') || null;
+        return `${Blockly.Ruby.spriteName()}.when(receive:, "${message}") do\n`;
+    };
+
+    // TODO messageが文字化けするのを修正する
+    Blockly.Ruby.event_broadcast = function (block) {
+        const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
+        return `broadcast("${message}")\n`;
+    };
+
+    // TODO messageが文字化けするのを修正する
+    Blockly.Ruby.event_broadcastandwait = function (block) {
+        const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
+        return `broadcast_and_wait("${message}")\n`;
+    };
+
+    Blockly.Ruby.event_broadcast_menu = function (block) {
+        const message = block.getFieldValue('BROADCAST_OPTION') || null;
+        return [message, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.event_whenstageclicked = function (block) {
+        Blockly.Ruby.targetEventBlock = block;
+        return `Stage.when(:stage_clicked) do\n`;
+    };
+
+
     return Blockly;
 }

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -5,6 +5,7 @@ import MathBlocks from './math.js';
 import TextBlocks from './text.js';
 import MotionBlocks from './motion.js';
 import LooksBlocks from './looks.js';
+import SoundBlocks from './sound.js';
 import EventBlocks from './event.js';
 import ControlBlocks from './control.js';
 
@@ -365,6 +366,7 @@ export default function (Blockly) {
 
     Blockly = MotionBlocks(Blockly);
     Blockly = LooksBlocks(Blockly);
+    Blockly = SoundBlocks(Blockly);
     Blockly = EventBlocks(Blockly);
     Blockly = ControlBlocks(Blockly);
 

--- a/src/lib/ruby-generator/sound.js
+++ b/src/lib/ruby-generator/sound.js
@@ -11,12 +11,12 @@ export default function (Blockly){
 
     Blockly.Ruby.sound_playuntildone = function (block) {
         const sound = Blockly.Ruby.valueToCode(block, 'SOUND_MENU', Blockly.Ruby.ORDER_NONE) || null;
-        return `play_sound(name: "${sound}")\n`;
+        return `Sound.play_until_done(name: "${sound}")\n`;
     };
 
     Blockly.Ruby.sound_play = function (block) {
         const sound = Blockly.Ruby.valueToCode(block, 'SOUND_MENU', Blockly.Ruby.ORDER_NONE) || null;
-        return `play_start(name: "${sound}")\n`;
+        return `Sound.play(name: "${sound}")\n`;
     };
 
     Blockly.Ruby.sound_stopallsounds = function () {
@@ -41,16 +41,16 @@ export default function (Blockly){
 
     Blockly.Ruby.sound_changevolumeby = function (block) {
         const volume = Blockly.Ruby.valueToCode(block, 'VOLUME', Blockly.Ruby.ORDER_NONE) || '0';
-        return `change_volume_by(${volume})\n`;
+        return `Sound.volume += ${volume}\n`;
     };
 
     Blockly.Ruby.sound_setvolumeto = function (block) {
         const volume = Blockly.Ruby.valueToCode(block, 'VOLUME', Blockly.Ruby.ORDER_NONE) || '0';
-        return `set_volume(${volume})\n`;
+        return `Sound.volume = ${volume}\n`;
     };
 
     Blockly.Ruby.sound_volume = function () {
-        return ['sound', Blockly.Ruby.ORDER_ATOMIC];
+        return ['Sound.volume', Blockly.Ruby.ORDER_ATOMIC];
     };
 
     return Blockly;

--- a/src/lib/ruby-generator/sound.js
+++ b/src/lib/ruby-generator/sound.js
@@ -1,0 +1,57 @@
+/**
+ * Define Ruby with Sound Blocks
+ * @param {Blockly} Blockly The ScratchBlocks
+ * @return {Blockly} Blockly defined Ruby generator.
+ */
+export default function (Blockly){
+    Blockly.Ruby.sound_sounds_menu = function (block) {
+        const sound = block.getFieldValue('SOUND_MENU') || null;
+        return [sound, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.sound_playuntildone = function (block) {
+        const sound = Blockly.Ruby.valueToCode(block, 'SOUND_MENU', Blockly.Ruby.ORDER_NONE) || null;
+        return `play_sound(name: "${sound}")\n`;
+    };
+
+    Blockly.Ruby.sound_play = function (block) {
+        const sound = Blockly.Ruby.valueToCode(block, 'SOUND_MENU', Blockly.Ruby.ORDER_NONE) || null;
+        return `play_start(name: "${sound}")\n`;
+    };
+
+    Blockly.Ruby.sound_stopallsounds = function () {
+        return 'stop_all_sounds\n';
+    };
+
+    Blockly.Ruby.sound_changeeffectby = function (block) {
+        const effect = block.getFieldValue('EFFECT') || null;
+        const value = Blockly.Ruby.valueToCode(block, 'VALUE', Blockly.Ruby.ORDER_NONE) || '0';
+        return `change_effect_by(effect: "${effect}", value: ${value})\n`;
+    };
+
+    Blockly.Ruby.sound_seteffectto = function (block) {
+        const effect = block.getFieldValue('EFFECT') || null;
+        const value = Blockly.Ruby.valueToCode(block, 'VALUE', Blockly.Ruby.ORDER_NONE) || '0';
+        return `set_effect(effect: "${effect}",value: ${value})\n`;
+    };
+
+    Blockly.Ruby.sound_cleareffects = function () {
+        return 'clear_effects\n';
+    };
+
+    Blockly.Ruby.sound_changevolumeby = function (block) {
+        const volume = Blockly.Ruby.valueToCode(block, 'VOLUME', Blockly.Ruby.ORDER_NONE) || '0';
+        return `change_volume_by(${volume})\n`;
+    };
+
+    Blockly.Ruby.sound_setvolumeto = function (block) {
+        const volume = Blockly.Ruby.valueToCode(block, 'VOLUME', Blockly.Ruby.ORDER_NONE) || '0';
+        return `set_volume(${volume})\n`;
+    };
+
+    Blockly.Ruby.sound_volume = function () {
+        return ['sound', Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    return Blockly;
+}

--- a/src/lib/ruby-generator/text.js
+++ b/src/lib/ruby-generator/text.js
@@ -5,8 +5,8 @@
  */
 export default function (Blockly) {
     Blockly.Ruby.text = function (block) {
-        const code = Blockly.Ruby.quote_(block.getFieldValue('TEXT'));
-        return [code, Blockly.Ruby.ORDER_ATOMIC];
+        const text = Blockly.Ruby.quote_(block.getFieldValue('TEXT'));
+        return [text, Blockly.Ruby.ORDER_ATOMIC];
     };
 
     return Blockly;


### PR DESCRIPTION
- sound-blocks

命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-16 17-09-28](https://user-images.githubusercontent.com/23467008/47058168-e2b1c680-d1fe-11e8-81e5-c4642baf7f84.png) | ![screenshot from 2018-10-16 17-09-34](https://user-images.githubusercontent.com/23467008/47058314-84d1ae80-d1ff-11e8-9c0b-f49d3929f977.png)


- event-blocks
Rubyタブの方に関してですが、日本語が含まれると文字が若干被ってしまうところもあります。
また、メッセージが文字化けするという問題が残っています。

命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-16 16-59-59](https://user-images.githubusercontent.com/23467008/47058240-37554180-d1ff-11e8-8948-97654355354f.png) | ![screenshot from 2018-10-16 16-59-52](https://user-images.githubusercontent.com/23467008/47058243-3ae8c880-d1ff-11e8-939c-12cc0386353a.png)

- control
止める｛すべて｝のブロックのみ値を取得する方法がわかりませんでした。
block.getFieldValue('ここの部分がわからない')

命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-17 11-09-05](https://user-images.githubusercontent.com/23467008/47058214-1856af80-d1ff-11e8-9eb8-bc920f349cde.png) | ![screenshot from 2018-10-17 11-09-10](https://user-images.githubusercontent.com/23467008/47058219-1d1b6380-d1ff-11e8-9f7e-8c0eff50d0fe.png)

