### PR TITLE
AceEditorのフォントを指定しました

### DIFF
--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -18,6 +18,9 @@ const RubyTab = ({rubyCode}) => (
             useSoftTabs: true,
             showInvisibles: true
         }}
+        style={{
+            fontFamily: 'monaco'
+        }}
         theme="clouds"
         value={rubyCode}
         width="100%"

--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -19,7 +19,7 @@ const RubyTab = ({rubyCode}) => (
             showInvisibles: true
         }}
         style={{
-            fontFamily: 'monaco'
+            fontFamily: ['Monaco', 'Menlo', 'Consolas', 'source-code-pro', 'monospace']
         }}
         theme="clouds"
         value={rubyCode}


### PR DESCRIPTION
#59  に対応しました。
Linux と WindowsのGoogle Chromeで確認済み。
![screenshot from 2018-10-18 10-40-07](https://user-images.githubusercontent.com/23467008/47126406-67661880-d2c3-11e8-96fc-46456ed0c2ac.png)

指定順番及び 'monaco'がシングルクォートで括っているのは、eslintに従っているからです。