### PR TITLE
メッセージが符号化されており、元のメッセージが把握できない

### DIFF
--- a/src/lib/ruby-generator/event.js
+++ b/src/lib/ruby-generator/event.js
@@ -35,22 +35,22 @@ export default function (Blockly) {
 
     Blockly.Ruby.event_whenbroadcastreceived = function (block) {
         Blockly.Ruby.targetEventBlock = block;
-        const message = block.getFieldValue('BROADCAST_OPTION') || null;
-        return `${Blockly.Ruby.spriteName()}.when(receive:, "${message}") do\n`;
+        const message = Blockly.Ruby.broadcastMessageName(block.getFieldValue('BROADCAST_OPTION'));
+        return `${Blockly.Ruby.spriteName()}.when(receive:, ${message}) do\n`;
     };
 
     Blockly.Ruby.event_broadcast = function (block) {
         const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
-        return `broadcast("${message}")\n`;
+        return `broadcast(${message})\n`;
     };
 
     Blockly.Ruby.event_broadcastandwait = function (block) {
         const message = Blockly.Ruby.valueToCode(block, 'BROADCAST_INPUT', Blockly.Ruby.ORDER_NONE) || null;
-        return `broadcast_and_wait("${message}")\n`;
+        return `broadcast_and_wait(${message})\n`;
     };
 
     Blockly.Ruby.event_broadcast_menu = function (block) {
-        const message = block.getFieldValue('BROADCAST_OPTION') || null;
+        const message = Blockly.Ruby.broadcastMessageName(block.getFieldValue('BROADCAST_OPTION'));
         return [message, Blockly.Ruby.ORDER_ATOMIC];
     };
 

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -322,6 +322,17 @@ export default function (Blockly) {
         return this.editingTarget.sprite.name;
     };
 
+    Blockly.Ruby.broadcastMessageName = function (name) {
+        const bm = this.editingTarget.lookupBroadcastMsg(name);
+        let message = null;
+        if (bm) {
+            return Blockly.Ruby.quote_(bm.name);
+        }
+        else {
+            return null;
+        }
+    };
+
     Blockly.Ruby.workspaceToCode_ = Blockly.Ruby.workspaceToCode;
 
     Blockly.Ruby.workspaceToCode = function(block, target) {


### PR DESCRIPTION
原因は、block.getFieldValue('BROADCAST_OPTION')で取得できるのはメッセージのID
だった。IDに対応するメッセージの名前は、lookupBroadcastMsgの戻り値のオブジェクトに
格納されていた。

#60 
