### PR TITLE
Operatorの命令ブロックをRubyに変換できるようにしました

### DIFF
--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -8,6 +8,7 @@ import LooksBlocks from './looks.js';
 import SoundBlocks from './sound.js';
 import EventBlocks from './event.js';
 import ControlBlocks from './control.js';
+import OperatorsBlocks from './operators.js';
 
 /**
  * Define Ruby
@@ -390,6 +391,7 @@ export default function (Blockly) {
     Blockly = SoundBlocks(Blockly);
     Blockly = EventBlocks(Blockly);
     Blockly = ControlBlocks(Blockly);
+    Blockly = OperatorsBlocks(Blockly);
 
     return Blockly;
 }

--- a/src/lib/ruby-generator/operators.js
+++ b/src/lib/ruby-generator/operators.js
@@ -5,85 +5,98 @@
  */
 export default function (Blockly) {
     Blockly.Ruby.operator_add = function (block) {
-        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
-        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`${num1} + ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_ADDITIVE;
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', order) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', order) || '0';
+        return [`${num1} + ${num2}`, order];
     };
 
     Blockly.Ruby.operator_subtract = function (block) {
-        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
-        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`${num1} - ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_ADDITIVE;
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', order) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', order) || '0';
+        return [`${num1} - ${num2}`, Blockly.Ruby.ORDER_ADDITIVE];
     };
 
     Blockly.Ruby.operator_multiply = function (block) {
-        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
-        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`${num1} * ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_MULTIPLICATIVE;
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', order) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', order) || '0';
+        return [`${num1} * ${num2}`, order];
     };
 
     Blockly.Ruby.operator_divide = function (block) {
-        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
-        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '1';
-        return [`${num1} / ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_MULTIPLICATIVE;
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', order) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', order) || '1';
+        return [`${num1} / ${num2}`, order];
     };
 
     Blockly.Ruby.operator_random = function (block) {
-        const fromNum = Blockly.Ruby.valueToCode(block, 'FROM', Blockly.Ruby.ORDER_NONE) || '0';
-        const toNum = Blockly.Ruby.valueToCode(block, 'TO', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`rand(${fromNum}..${toNum})`, Blockly.Ruby.ORDER_ATOMIC];
+        const fromNum = Blockly.Ruby.valueToCode(block, 'FROM', Blockly.Ruby.ORDER_RANGE) || '0';
+        const toNum = Blockly.Ruby.valueToCode(block, 'TO', Blockly.Ruby.ORDER_RANGE) || '0';
+        return [`rand(${fromNum}..${toNum})`, Blockly.Ruby.ORDER_FUNCTION_CALL];
     };
 
     Blockly.Ruby.operator_gt = function (block) {
-        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
-        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`Cast.compare(${operand1}, ${operand2}) > 0`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_RELATIONAL;
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', order) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', order) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) > 0`, order];
     };
 
     Blockly.Ruby.operator_lt = function (block) {
-        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
-        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`Cast.compare(${operand1}, ${operand2}) < 0`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_RELATIONAL;
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', order) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', order) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) < 0`, order];
     };
 
     Blockly.Ruby.operator_equals = function (block) {
-        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
-        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`Cast.compare(${operand1}, ${operand2}) == 0`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_EQUALS;
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', order) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', order) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) == 0`, order];
     };
 
     Blockly.Ruby.operator_and = function (block) {
-        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || 'false';
-        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || 'false';
-        return [`${operand1} && ${operand2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_LOGICAL_AND;
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', order) || 'false';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', order) || 'false';
+        return [`${operand1} && ${operand2}`, order];
     };
 
     Blockly.Ruby.operator_or = function (block) {
-        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || 'false';
-        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || 'false';
-        return [`${operand1} || ${operand2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_LOGICAL_OR;
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', order) || 'false';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', order) || 'false';
+        return [`${operand1} || ${operand2}`, order];
     };
 
     Blockly.Ruby.operator_not = function (block) {
-        const operand = Blockly.Ruby.valueToCode(block, 'OPERAND', Blockly.Ruby.ORDER_NONE) || 'false';
-        return [`!${operand}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_UNARY_SIGN;
+        const operand = Blockly.Ruby.valueToCode(block, 'OPERAND', order) || 'false';
+        return [`!${operand}`, order];
     };
 
     Blockly.Ruby.operator_join = function (block) {
-        const rightStr = Blockly.Ruby.valueToCode(block, 'STRING1', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
-        const leftStr = Blockly.Ruby.valueToCode(block, 'STRING2', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
-        return [`${rightStr} + ${leftStr}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_ADDITIVE;
+        const rightStr = Blockly.Ruby.valueToCode(block, 'STRING1', order) || Blockly.Ruby.quote_('');
+        const leftStr = Blockly.Ruby.valueToCode(block, 'STRING2', order) || Blockly.Ruby.quote_('');
+        return [`${rightStr} + ${leftStr}`, order];
     };
 
     Blockly.Ruby.operator_letter_of = function (block) {
-        const str = Blockly.Ruby.valueToCode(block, 'STRING', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
-        const letter = Blockly.Ruby.valueToCode(block, 'LETTER', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
-        return [`${str}[${letter}]`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_FUNCTION_CALL;
+        const str = Blockly.Ruby.valueToCode(block, 'STRING', order) || Blockly.Ruby.quote_('');
+        const letter = Blockly.Ruby.valueToCode(block, 'LETTER', Blockly.Ruby.ORDER_INDEX) || '0';
+        return [`${str}[${letter}]`, order];
     };
 
     Blockly.Ruby.operator_length = function (block) {
-        const str = Blockly.Ruby.valueToCode(block, 'STRING', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
-        return [`${str}.length`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_FUNCTION_CALL;
+        const str = Blockly.Ruby.valueToCode(block, 'STRING', order) || Blockly.Ruby.quote_('');
+        return [`${str}.length`, order];
     };
 
     Blockly.Ruby.operator_contains = function (block) {
@@ -93,50 +106,53 @@ export default function (Blockly) {
     };
 
     Blockly.Ruby.operator_mod = function (block) {
-        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
-        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`${num1} % ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_MULTIPLICATIVE;
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', order) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', order) || '0';
+        return [`${num1} % ${num2}`, order];
     };
 
     Blockly.Ruby.operator_round = function (block) {
-        const num = Blockly.Ruby.valueToCode(block, 'NUM', Blockly.Ruby.ORDER_NONE) || '0';
-        return [`${num}.round`, Blockly.Ruby.ORDER_ATOMIC];
+        const order = Blockly.Ruby.ORDER_FUNCTION_CALL;
+        const num = Blockly.Ruby.valueToCode(block, 'NUM', order) || '0';
+        return [`${num}.round`, order];
     };
 
     Blockly.Ruby.operator_mathop = function (block) {
-        const num = Blockly.Ruby.valueToCode(block, 'NUM', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        const order = Blockly.Ruby.ORDER_FUNCTION_CALL;
+        const num = Blockly.Ruby.valueToCode(block, 'NUM', Blockly.Ruby.ORDER_NONE) || '0';
         const operator = block.getFieldValue('OPERATOR') || null;
         switch (operator) {
         case 'abs':
-            return [`${num}.abs`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`${num}.abs`, order];
         case 'floor':
-            return [`${num}.floor`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`${num}.floor`, order];
         case 'ceiling':
-            return [`${num}.ceil`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`${num}.ceil`, order];
         case 'sqrt':
-            return [`Math.sqrt(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.sqrt(${num})`, order];
         case 'sin':
-            return [`Math.sin(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.sin(${num})`, order];
         case 'cos':
-            return [`Math.cos(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.cos(${num})`, order];
         case 'tan':
-            return [`Math.tan(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.tan(${num})`, order];
         case 'asin':
-            return [`Math.asin(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.asin(${num})`, order];
         case 'acos':
-            return [`Math.acos(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.acos(${num})`, order];
         case 'atan':
-            return [`Math.atan(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.atan(${num})`, order];
         case 'ln':
-            return [`Math.log(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.log(${num})`, order];
         case 'log':
-            return [`Math.log10(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math.log10(${num})`, order];
         case 'e ^':
-            return [`Math::E**${num}`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`Math::E ** ${num}`, order];
         case '10 ^':
-            return [`10**${num}`, Blockly.Ruby.ORDER_ATOMIC];
+            return [`10 ** ${num}`, order];
         default:
-            return [null, Blockly.Ruby.ORDER_ATOMIC];
+            return [null, order];
         }
     };
 

--- a/src/lib/ruby-generator/operators.js
+++ b/src/lib/ruby-generator/operators.js
@@ -1,0 +1,144 @@
+/**
+ * Define Ruby with Operators Blocks
+ * @param {Blockly} Blockly The ScratchBlocks
+ * @return {Blockly} Blockly defined Ruby generator.
+ */
+export default function (Blockly) {
+    Blockly.Ruby.operator_add = function (block) {
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`${num1} + ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_subtract = function (block) {
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`${num1} - ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_multiply = function (block) {
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`${num1} * ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_divide = function (block) {
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '1';
+        return [`${num1} / ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_random = function (block) {
+        const fromNum = Blockly.Ruby.valueToCode(block, 'FROM', Blockly.Ruby.ORDER_NONE) || '0';
+        const toNum = Blockly.Ruby.valueToCode(block, 'TO', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`rand(${fromNum}..${toNum})`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_gt = function (block) {
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) > 0`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_lt = function (block) {
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) < 0`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_equals = function (block) {
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || '0';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`Cast.compare(${operand1}, ${operand2}) == 0`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_and = function (block) {
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || 'false';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || 'false';
+        return [`${operand1} && ${operand2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_or = function (block) {
+        const operand1 = Blockly.Ruby.valueToCode(block, 'OPERAND1', Blockly.Ruby.ORDER_NONE) || 'false';
+        const operand2 = Blockly.Ruby.valueToCode(block, 'OPERAND2', Blockly.Ruby.ORDER_NONE) || 'false';
+        return [`${operand1} || ${operand2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_not = function (block) {
+        const operand = Blockly.Ruby.valueToCode(block, 'OPERAND', Blockly.Ruby.ORDER_NONE) || 'false';
+        return [`!${operand}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_join = function (block) {
+        const rightStr = Blockly.Ruby.valueToCode(block, 'STRING1', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        const leftStr = Blockly.Ruby.valueToCode(block, 'STRING2', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        return [`${rightStr} + ${leftStr}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_letter_of = function (block) {
+        const str = Blockly.Ruby.valueToCode(block, 'STRING', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        const letter = Blockly.Ruby.valueToCode(block, 'LETTER', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        return [`${str}[${letter}]`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_length = function (block) {
+        const str = Blockly.Ruby.valueToCode(block, 'STRING', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        return [`${str}.length`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_contains = function (block) {
+        const str1 = Blockly.Ruby.valueToCode(block, 'STRING1', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        const str2 = Blockly.Ruby.valueToCode(block, 'STRING2', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        return [`${str1}.include?(${str2})`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_mod = function (block) {
+        const num1 = Blockly.Ruby.valueToCode(block, 'NUM1', Blockly.Ruby.ORDER_NONE) || '0';
+        const num2 = Blockly.Ruby.valueToCode(block, 'NUM2', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`${num1} % ${num2}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_round = function (block) {
+        const num = Blockly.Ruby.valueToCode(block, 'NUM', Blockly.Ruby.ORDER_NONE) || '0';
+        return [`${num}.round`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.operator_mathop = function (block) {
+        const num = Blockly.Ruby.valueToCode(block, 'NUM', Blockly.Ruby.ORDER_NONE) || Blockly.Ruby.quote_('');
+        const operator = block.getFieldValue('OPERATOR') || null;
+        switch (operator) {
+        case 'abs':
+            return [`${num}.abs`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'floor':
+            return [`${num}.floor`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'ceiling':
+            return [`${num}.ceil`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'sqrt':
+            return [`Math.sqrt(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'sin':
+            return [`Math.sin(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'cos':
+            return [`Math.cos(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'tan':
+            return [`Math.tan(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'asin':
+            return [`Math.asin(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'acos':
+            return [`Math.acos(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'atan':
+            return [`Math.atan(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'ln':
+            return [`Math.log(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'log':
+            return [`Math.log10(${num})`, Blockly.Ruby.ORDER_ATOMIC];
+        case 'e ^':
+            return [`Math::E**${num}`, Blockly.Ruby.ORDER_ATOMIC];
+        case '10 ^':
+            return [`10**${num}`, Blockly.Ruby.ORDER_ATOMIC];
+        default:
+            return [null, Blockly.Ruby.ORDER_ATOMIC];
+        }
+    };
+
+    return Blockly;
+}


### PR DESCRIPTION
命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-19 10-45-36](https://user-images.githubusercontent.com/23467008/47193534-6817b100-d38e-11e8-991f-85f9cd3957cf.png) | ![screenshot from 2018-10-19 10-45-51](https://user-images.githubusercontent.com/23467008/47193537-6e0d9200-d38e-11e8-9b50-b13913f87d05.png)

- 含まれるのブロックについて
![screenshot from 2018-10-19 10-29-35](https://user-images.githubusercontent.com/23467008/47193557-8da4ba80-d38e-11e8-9f76-3c1e7cd29318.png)
Rubyのコード的に ${str1}.include(${str2})? にしましたが、${str1}.contains(${str2})? の方がよろしいでしょうか？