### PR TITLE
Rubyタブに入力したソースをコードタブの命令ブロックに変換できる

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -32,7 +32,6 @@ import Alerts from '../../containers/alerts.jsx';
 import DragLayer from '../../containers/drag-layer.jsx';
 import ConnectionModal from '../../containers/connection-modal.jsx';
 
-import {rubyCodeShape} from '../../reducers/ruby-code';
 
 import layout, {STAGE_SIZE_MODES} from '../../lib/layout-constants';
 import {resolveStageSize} from '../../lib/screen-utils';
@@ -110,7 +109,6 @@ const GUIComponent = props => {
         stageSizeMode,
         targetIsStage,
         tipsLibraryVisible,
-        rubyCode,
         vm,
         ...componentProps
     } = omit(props, 'dispatch');
@@ -321,12 +319,10 @@ const GUIComponent = props => {
                                     {soundsTabVisible ? <SoundTab vm={vm} /> : null}
                                 </TabPanel>
                                 <TabPanel className={tabClassNames.tabPanel}>
-                                    {rubyTabVisible ? (
-                                        <RubyTab
-                                            rubyCode={rubyCode}
-                                            vm={vm}
-                                        />
-                                    ) : null}
+                                    <RubyTab
+                                        isVisible={rubyTabVisible}
+                                        vm={vm}
+                                    />
                                 </TabPanel>
                             </Tabs>
                             {backpackVisible ? (
@@ -401,7 +397,6 @@ GUIComponent.propTypes = {
     onToggleLoginOpen: PropTypes.func,
     onUpdateProjectTitle: PropTypes.func,
     renderLogin: PropTypes.func,
-    rubyCode: rubyCodeShape,
     rubyTabVisible: PropTypes.bool,
     showComingSoon: PropTypes.bool,
     soundsTabVisible: PropTypes.bool,

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -4,6 +4,7 @@ import {defineMessages, FormattedMessage, injectIntl, intlShape} from 'react-int
 import PropTypes from 'prop-types';
 import bindAll from 'lodash.bindall';
 import React from 'react';
+import VM from 'scratch-vm';
 
 import Box from '../box/box.jsx';
 import Button from '../button/button.jsx';
@@ -64,6 +65,8 @@ import dropdownCaret from './dropdown-caret.svg';
 import languageIcon from '../language-selector/language-icon.svg';
 
 import smalrubyLogo from './hatti.svg';
+
+import {updateRubyCodeTarget} from '../../reducers/ruby-code';
 
 const ariaMessages = defineMessages({
     language: {
@@ -140,6 +143,7 @@ class MenuBar extends React.Component {
             'handleClickRemix',
             'handleClickSave',
             'handleClickSaveAsCopy',
+            'handleClickGenerateRubyFromCode',
             'handleClickSeeCommunity',
             'handleClickShare',
             'handleCloseFileMenuAndThen',
@@ -170,6 +174,10 @@ class MenuBar extends React.Component {
     handleClickSaveAsCopy () {
         this.props.onClickSaveAsCopy();
         this.props.onRequestCloseFile();
+    }
+    handleClickGenerateRubyFromCode () {
+        this.props.updateRubyCodeTargetState(this.props.vm.editingTarget);
+        this.props.onRequestCloseEdit();
     }
     handleClickSeeCommunity (waitForUpdate) {
         if (this.props.canSave) { // save before transitioning to project page
@@ -265,6 +273,13 @@ class MenuBar extends React.Component {
                 defaultMessage="New"
                 description="Menu bar item for creating a new project"
                 id="gui.menuBar.new"
+            />
+        );
+        const generateRubyFromCodeMessage = (
+            <FormattedMessage
+                defaultMessage="Generate Ruby from Code"
+                description="Menu bar item for generating ruby from code"
+                id="gui.smalruby3.menuBar.generateRubyFromCode"
             />
         );
         const remixButton = (
@@ -453,6 +468,14 @@ class MenuBar extends React.Component {
                                             )}
                                         </MenuItem>
                                     )}</TurboMode>
+                                </MenuSection>
+                                <MenuSection>
+                                    <MenuItem
+                                        isRtl={this.props.isRtl}
+                                        onClick={this.handleClickGenerateRubyFromCode}
+                                    >
+                                        {generateRubyFromCodeMessage}
+                                    </MenuItem>
                                 </MenuSection>
                             </MenuBarMenu>
                         </div>
@@ -722,7 +745,9 @@ MenuBar.propTypes = {
     renderLogin: PropTypes.func,
     sessionExists: PropTypes.bool,
     showComingSoon: PropTypes.bool,
-    username: PropTypes.string
+    updateRubyCodeTargetState: PropTypes.func,
+    username: PropTypes.string,
+    vm: PropTypes.instanceOf(VM)
 };
 
 MenuBar.defaultProps = {
@@ -743,7 +768,8 @@ const mapStateToProps = state => {
         loginMenuOpen: loginMenuOpen(state),
         projectTitle: state.scratchGui.projectTitle,
         sessionExists: state.session && typeof state.session.session !== 'undefined',
-        username: user ? user.username : null
+        username: user ? user.username : null,
+        vm: state.scratchGui.vm
     };
 };
 
@@ -764,7 +790,8 @@ const mapDispatchToProps = dispatch => ({
     onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy()),
-    onSeeCommunity: () => dispatch(setPlayer(true))
+    onSeeCommunity: () => dispatch(setPlayer(true)),
+    updateRubyCodeTargetState: target => dispatch(updateRubyCodeTarget(target))
 });
 
 export default injectIntl(connect(

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -25,12 +25,10 @@ import {updateToolbox} from '../reducers/toolbox';
 import {activateColorPicker} from '../reducers/color-picker';
 import {closeExtensionLibrary, openSoundRecorder, openConnectionModal} from '../reducers/modals';
 import {activateCustomProcedures, deactivateCustomProcedures} from '../reducers/custom-procedures';
-import {updateRubyCode} from '../reducers/ruby-code';
 import {setConnectionModalExtensionId} from '../reducers/connection-modal';
 
 import {
     activateTab,
-    BLOCKS_TAB_INDEX,
     SOUNDS_TAB_INDEX
 } from '../reducers/editor-tab';
 
@@ -168,9 +166,6 @@ class Blocks extends React.Component {
         } else {
             this.workspace.setVisible(false);
         }
-        if (!this.props.blocksTabVisible) {
-            this.props.updateRubyCodeState(this.props.vm.editingTarget);
-        }
     }
     componentWillUnmount () {
         this.detachVM();
@@ -274,9 +269,6 @@ class Blocks extends React.Component {
                 this.updateToolboxBlockValue(`${prefix}y`, Math.round(this.props.vm.editingTarget.y).toString());
             });
         }
-        if (!this.props.blocksTabVisible) {
-            this.props.updateRubyCodeState(this.props.vm.editingTarget);
-        }
     }
     onWorkspaceMetricsChange () {
         const target = this.props.vm.editingTarget;
@@ -324,6 +316,33 @@ class Blocks extends React.Component {
         const dom = this.ScratchBlocks.Xml.textToDom(data.xml);
         try {
             this.ScratchBlocks.Xml.clearWorkspaceAndLoadFromXml(dom, this.workspace);
+
+            // When we converted blocks from Ruby, update top block positions.
+            if (this.props.vm.editingTarget) {
+                const blocks = this.props.vm.editingTarget.blocks;
+                const scripts = blocks.getScripts();
+                let fromRuby = false;
+                for (let i = 0; i < scripts.length; i++) {
+                    const topBlockId = scripts[i];
+                    const topBlock = blocks.getBlock(topBlockId);
+                    if (typeof topBlock.x === 'undefined' || typeof topBlock.y === 'undefined') {
+                        fromRuby = true;
+                        break;
+                    }
+                }
+                if (fromRuby) {
+                    this.workspace.cleanUp();
+
+                    this.workspace.getTopBlocks(false).forEach(wsTopBlock => {
+                        const topBlock = blocks.getBlock(wsTopBlock.id);
+                        if (topBlock) {
+                            const xy = wsTopBlock.getRelativeToSurfaceXY();
+                            topBlock.x = xy.x;
+                            topBlock.y = xy.y;
+                        }
+                    });
+                }
+            }
         } catch (error) {
             // The workspace is likely incomplete. What did update should be
             // functional.
@@ -438,7 +457,6 @@ class Blocks extends React.Component {
         /* eslint-disable no-unused-vars */
         const {
             anyModalVisible,
-            blocksTabVisible,
             canUseCloud,
             customProceduresVisible,
             extensionLibraryVisible,
@@ -451,7 +469,6 @@ class Blocks extends React.Component {
             onOpenConnectionModal,
             onOpenSoundRecorder,
             updateToolboxState,
-            updateRubyCodeState,
             onActivateCustomProcedures,
             onRequestCloseExtensionLibrary,
             onRequestCloseCustomProcedures,
@@ -501,7 +518,6 @@ class Blocks extends React.Component {
 
 Blocks.propTypes = {
     anyModalVisible: PropTypes.bool,
-    blocksTabVisible: PropTypes.bool,
     canUseCloud: PropTypes.bool,
     customProceduresVisible: PropTypes.bool,
     extensionLibraryVisible: PropTypes.bool,
@@ -539,7 +555,6 @@ Blocks.propTypes = {
     }),
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,
     toolboxXML: PropTypes.string,
-    updateRubyCodeState: PropTypes.func,
     updateToolboxState: PropTypes.func,
     vm: PropTypes.instanceOf(VM).isRequired
 };
@@ -582,7 +597,6 @@ const mapStateToProps = state => ({
         Object.keys(state.scratchGui.modals).some(key => state.scratchGui.modals[key]) ||
         state.scratchGui.mode.isFullScreen
     ),
-    blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
     extensionLibraryVisible: state.scratchGui.modals.extensionLibrary,
     isRtl: state.locales.isRtl,
     locale: state.locales.locale,
@@ -610,9 +624,6 @@ const mapDispatchToProps = dispatch => ({
     },
     updateToolboxState: toolboxXML => {
         dispatch(updateToolbox(toolboxXML));
-    },
-    updateRubyCodeState: target => {
-        dispatch(updateRubyCode(target));
     }
 });
 

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -5,6 +5,7 @@ import makeToolboxXML from '../lib/make-toolbox-xml';
 import PropTypes from 'prop-types';
 import React from 'react';
 import VMScratchBlocks from '../lib/blocks';
+import defineRubyBlocks from '../lib/define-ruby-blocks';
 import VM from 'scratch-vm';
 
 import analytics from '../lib/analytics';
@@ -49,7 +50,7 @@ const DroppableBlocks = DropAreaHOC([
 class Blocks extends React.Component {
     constructor (props) {
         super(props);
-        this.ScratchBlocks = VMScratchBlocks(props.vm);
+        this.ScratchBlocks = defineRubyBlocks(VMScratchBlocks(props.vm));
         bindAll(this, [
             'attachVM',
             'detachVM',

--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -7,6 +7,8 @@ import {connect} from 'react-redux';
 import analytics from '../lib/analytics';
 import ControlsComponent from '../components/controls/controls.jsx';
 
+import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
+
 class Controls extends React.Component {
     constructor (props) {
         super(props);
@@ -17,6 +19,11 @@ class Controls extends React.Component {
     }
     handleGreenFlagClick (e) {
         e.preventDefault();
+
+        if (!this.props.targetCodeToBlocks()) {
+            return;
+        }
+
         if (e.shiftKey) {
             this.props.vm.setTurboMode(!this.props.turbo);
         } else {
@@ -38,6 +45,7 @@ class Controls extends React.Component {
     render () {
         const {
             vm, // eslint-disable-line no-unused-vars
+            targetCodeToBlocks, // eslint-disable-line no-unused-vars
             projectRunning,
             turbo,
             ...props
@@ -56,6 +64,7 @@ class Controls extends React.Component {
 
 Controls.propTypes = {
     projectRunning: PropTypes.bool.isRequired,
+    targetCodeToBlocks: PropTypes.func,
     turbo: PropTypes.bool.isRequired,
     vm: PropTypes.instanceOf(VM)
 };
@@ -67,4 +76,4 @@ const mapStateToProps = state => ({
 // no-op function to prevent dispatch prop being passed to component
 const mapDispatchToProps = () => ({});
 
-export default connect(mapStateToProps, mapDispatchToProps)(Controls);
+export default RubyToBlocksConverterHOC(connect(mapStateToProps, mapDispatchToProps)(Controls));

--- a/src/containers/green-flag.jsx
+++ b/src/containers/green-flag.jsx
@@ -32,6 +32,7 @@ class GreenFlag extends React.Component {
     }
     handleClick (e) {
         e.preventDefault();
+
         if (e.shiftKey) {
             this.props.vm.setTurboMode(!this.props.vm.runtime.turboMode);
         } else {

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -168,7 +168,6 @@ const mapStateToProps = state => {
         soundsTabVisible: state.scratchGui.editorTab.activeTabIndex === SOUNDS_TAB_INDEX,
         tipsLibraryVisible: state.scratchGui.modals.tipsLibrary,
         rubyTabVisible: state.scratchGui.editorTab.activeTabIndex === RUBY_TAB_INDEX,
-        rubyCode: state.scratchGui.rubyCode,
         vm: state.scratchGui.vm
     };
 };

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {projectTitleInitialState} from '../reducers/project-title';
 import RubyGenerator from '../lib/ruby-generator';
 import VM from 'scratch-vm';
+import {rubyCodeShape} from '../reducers/ruby-code';
 
 class RubyDownloader extends React.Component {
     constructor (props) {
@@ -23,10 +24,16 @@ class RubyDownloader extends React.Component {
             const sprite = this.props.sprites[id];
             targets[sprite.order + 1] = idToTarget[id];
         }
-        const code = RubyGenerator.targetsToCode(targets, {
+        const options = {
             requires: ['smalruby3'],
             withSpriteNew: true
-        });
+        };
+        if (this.props.rubyCode.modified) {
+            options.targetsCode = {
+                [this.props.rubyCode.target.id]: this.props.rubyCode.code
+            };
+        }
+        const code = RubyGenerator.targetsToCode(targets, options);
 
         return new Blob([code], {
             type: 'text/x-ruby-script'
@@ -77,6 +84,7 @@ RubyDownloader.propTypes = {
     className: PropTypes.string,
     onSaveFinished: PropTypes.func,
     projectFilename: PropTypes.string,
+    rubyCode: rubyCodeShape,
     sprites: PropTypes.objectOf(PropTypes.shape({
         id: PropTypes.string.isRequired,
         order: PropTypes.number.isRequired
@@ -94,7 +102,8 @@ const mapStateToProps = state => ({
     projectFilename: getProjectFilename(state.scratchGui.projectTitle, projectTitleInitialState),
     sprites: state.scratchGui.targets.sprites,
     stage: state.scratchGui.targets.stage,
-    vm: state.scratchGui.vm
+    vm: state.scratchGui.vm,
+    rubyCode: state.scratchGui.rubyCode
 });
 
 export default connect(

--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -1,39 +1,124 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 import AceEditor from 'react-ace';
-import {rubyCodeShape} from '../reducers/ruby-code';
+import {
+    rubyCodeShape,
+    updateRubyCode,
+    updateRubyCodeTarget
+} from '../reducers/ruby-code';
+import VM from 'scratch-vm';
+import {BLOCKS_TAB_INDEX} from '../reducers/editor-tab';
+
+import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
 
 import 'brace/mode/ruby';
 import 'brace/theme/clouds';
 
-const RubyTab = function (props) {
-    return (
-        <AceEditor
-            readOnly
-            editorProps={{$blockScrolling: true}}
-            fontSize={16}
-            height="inherit"
-            mode="ruby"
-            name="ruby-editor"
-            setOptions={{
-                tabSize: 2,
-                useSoftTabs: true,
-                showInvisibles: true
-            }}
-            style={{
-                fontFamily: ['Monaco', 'Menlo', 'Consolas', 'source-code-pro', 'monospace'],
-                borderTopRightRadius: '0.5rem',
-                borderBottomRightRadius: '0.5rem',
-                border: '1px solid hsla(0, 0%, 0%, 0.15)'
-            }}
-            theme="clouds"
-            value={props.rubyCode ? props.rubyCode.code : ''}
-            width="100%"
-        />
-    );
-};
+class RubyTab extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'setAceEditorRef'
+        ]);
+    }
+
+    componentDidUpdate (prevProps) {
+        let modified = this.props.rubyCode.modified;
+        if (modified) {
+            const targetId = this.props.rubyCode.target ? this.props.rubyCode.target.id : null;
+            const changedTarget =
+                  this.props.vm.editingTarget && this.props.rubyCode.target &&
+                  this.props.vm.editingTarget.id !== targetId;
+            if (changedTarget || this.props.blocksTabVisible) {
+                if (this.props.targetCodeToBlocks()) {
+                    modified = false;
+                } else {
+                    this.aceEditorRef.editor.focus();
+                }
+            }
+        }
+
+        if (!modified) {
+            if ((this.props.isVisible && !prevProps.isVisible) ||
+                (this.props.editingTarget && this.props.editingTarget !== prevProps.editingTarget)) {
+                this.props.updateRubyCodeTargetState(this.props.vm.editingTarget);
+            }
+        }
+
+        if (this.props.isVisible && !prevProps.isVisible) {
+            this.aceEditorRef.editor.renderer.updateFull();
+            this.aceEditorRef.editor.focus();
+        }
+    }
+
+    setAceEditorRef (ref) {
+        this.aceEditorRef = ref;
+    }
+
+
+    render () {
+        const {
+            onChange,
+            rubyCode
+        } = this.props;
+        const {
+            code,
+            errors
+        } = rubyCode;
+        return (
+            <AceEditor
+                annotations={errors}
+                editorProps={{$blockScrolling: true}}
+                fontSize={16}
+                height="inherit"
+                mode="ruby"
+                name="ruby-editor"
+                ref={this.setAceEditorRef}
+                setOptions={{
+                    tabSize: 2,
+                    useSoftTabs: true,
+                    showInvisibles: true
+                }}
+                style={{
+                    border: '1px solid hsla(0, 0%, 0%, 0.15)',
+                    borderBottomRightRadius: '0.5rem',
+                    borderTopRightRadius: '0.5rem',
+                    fontFamily: ['Monaco', 'Menlo', 'Consolas', 'source-code-pro', 'monospace']
+                }}
+                theme="clouds"
+                value={code}
+                width="100%"
+                onChange={onChange}
+            />
+        );
+    }
+}
 
 RubyTab.propTypes = {
-    rubyCode: rubyCodeShape
+    blocksTabVisible: PropTypes.bool,
+    editingTarget: PropTypes.string,
+    isVisible: PropTypes.bool,
+    onChange: PropTypes.func,
+    rubyCode: rubyCodeShape,
+    targetCodeToBlocks: PropTypes.func,
+    updateRubyCodeTargetState: PropTypes.func,
+    vm: PropTypes.instanceOf(VM).isRequired
 };
 
-export default RubyTab;
+const mapStateToProps = state => ({
+    blocksTabVisible: state.scratchGui.editorTab.activeTabIndex === BLOCKS_TAB_INDEX,
+    editingTarget: state.scratchGui.targets.editingTarget,
+    rubyCode: state.scratchGui.rubyCode
+});
+
+const mapDispatchToProps = dispatch => ({
+    onChange: code => dispatch(updateRubyCode(code)),
+    updateRubyCodeTargetState: target => dispatch(updateRubyCodeTarget(target))
+});
+
+export default RubyToBlocksConverterHOC(connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(RubyTab));

--- a/src/containers/sb3-downloader.jsx
+++ b/src/containers/sb3-downloader.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {projectTitleInitialState} from '../reducers/project-title';
 
+import RubyToBlocksConverterHOC from '../lib/ruby-to-blocks-converter-hoc.jsx';
+
 /**
  * Project saver component passes a downloadProject function to its child.
  * It expects this child to be a function with the signature
@@ -26,6 +28,10 @@ class SB3Downloader extends React.Component {
         ]);
     }
     downloadProject () {
+        if (!this.props.targetCodeToBlocks()) {
+            return;
+        }
+
         const downloadLink = document.createElement('a');
         document.body.appendChild(downloadLink);
 
@@ -71,7 +77,8 @@ SB3Downloader.propTypes = {
     className: PropTypes.string,
     onSaveFinished: PropTypes.func,
     projectFilename: PropTypes.string,
-    saveProjectSb3: PropTypes.func
+    saveProjectSb3: PropTypes.func,
+    targetCodeToBlocks: PropTypes.func
 };
 SB3Downloader.defaultProps = {
     className: ''
@@ -82,7 +89,7 @@ const mapStateToProps = state => ({
     projectFilename: getProjectFilename(state.scratchGui.projectTitle, projectTitleInitialState)
 });
 
-export default connect(
+export default RubyToBlocksConverterHOC(connect(
     mapStateToProps,
     () => ({}) // omit dispatch prop
-)(SB3Downloader);
+)(SB3Downloader));

--- a/src/containers/target-pane.jsx
+++ b/src/containers/target-pane.jsx
@@ -206,6 +206,7 @@ class TargetPane extends React.Component {
             onActivateTab, // eslint-disable-line no-unused-vars
             onReceivedBlocks, // eslint-disable-line no-unused-vars
             onHighlightTarget, // eslint-disable-line no-unused-vars
+            onChangeTarget, // eslint-disable-line no-unused-vars
             dispatchUpdateRestore, // eslint-disable-line no-unused-vars
             ...componentProps
         } = this.props;

--- a/src/lib/alerts/index.jsx
+++ b/src/lib/alerts/index.jsx
@@ -80,6 +80,17 @@ const alerts = [
         ),
         iconSpinner: true,
         level: AlertLevels.SUCCESS
+    },
+    {
+        alertId: 'convertRubyToBlocksError',
+        content: (
+            <FormattedMessage
+                defaultMessage="Could not convert Ruby to Code. Please fix Ruby!"
+                description="Message indicating that project could not be converted Ruby to Blocks"
+                id="gui.smalruby3.alerts.convertRubyToBlocksError"
+            />
+        ),
+        level: AlertLevels.WARN
     }
 ];
 

--- a/src/lib/define-ruby-blocks.js
+++ b/src/lib/define-ruby-blocks.js
@@ -1,0 +1,67 @@
+/**
+ * Define Ruby blocks
+ * @param {ScratchBlocks} ScratchBlocks target to define Ruby blocks.
+ * @return {ScratchBlocks} ScratchBlocks defined ScratchBlocks.
+ */
+export default function (ScratchBlocks) {
+    const name = 'ruby';
+    if (ScratchBlocks.Categories.hasOwnProperty(name)) {
+        return ScratchBlocks;
+    }
+    ScratchBlocks.Categories[name] = name;
+    ScratchBlocks.Colours[name] = {
+        primary: '#CC0043',
+        secondary: '#DB4D7B',
+        tertiary: '#7A0028'
+    };
+    ScratchBlocks.Extensions.register(
+        `colours_${name}`,
+        ScratchBlocks.ScratchBlocks.VerticalExtensions.colourHelper(name)
+    );
+
+    ScratchBlocks.Blocks.ruby_statement = {
+        init: function () {
+            this.jsonInit({
+                message0: '%1',
+                args0: [
+                    {
+                        type: 'input_value',
+                        name: 'STATEMENT'
+                    }
+                ],
+                category: ScratchBlocks.Categories.ruby,
+                extensions: ['colours_ruby', 'shape_statement']
+            });
+        }
+    };
+
+    ScratchBlocks.Blocks.ruby_statement_with_block = {
+        init: function () {
+            this.jsonInit({
+                message0: '%1 do %2',
+                message1: '%1',
+                message2: 'end',
+                args0: [
+                    {
+                        type: 'input_value',
+                        name: 'STATEMENT'
+                    },
+                    {
+                        type: 'input_value',
+                        name: 'ARGS'
+                    }
+                ],
+                args1: [
+                    {
+                        type: 'input_statement',
+                        name: 'SUBSTACK'
+                    }
+                ],
+                category: ScratchBlocks.Categories.ruby,
+                extensions: ['colours_ruby', 'shape_statement']
+            });
+        }
+    };
+
+    return ScratchBlocks;
+}

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -128,36 +128,41 @@ class Generator {
 
         this.init(options);
 
-        const codes = [];
-        const proceduresCodes = [];
-        const scripts = this.getScripts();
-        scripts.forEach(topBlockId => {
-            const block = this.getBlock(topBlockId);
-            let line = this.blockToCode(block);
-            if (_.isArray(line)) {
-                // Value blocks return tuples of code and operator order.
-                // Top-level blocks don't care about operator order.
-                //
-                // This block is a naked value.  Ask the language's code generator if
-                // it wants to append a semicolon, or something.
-                if (this.scrubNakedValue) {
-                    line = this.scrubNakedValue(line[0]);
+        let code;
+        if (options && options.hasOwnProperty('targetsCode') && options.targetsCode.hasOwnProperty(target.id)) {
+            code = `${options.targetsCode[target.id]}\n`.replace(/\n\s+$/, '\n');
+        } else {
+            const codes = [];
+            const proceduresCodes = [];
+            const scripts = this.getScripts();
+            scripts.forEach(topBlockId => {
+                const block = this.getBlock(topBlockId);
+                let line = this.blockToCode(block);
+                if (_.isArray(line)) {
+                    // Value blocks return tuples of code and operator order.
+                    // Top-level blocks don't care about operator order.
+                    //
+                    // This block is a naked value.  Ask the language's code generator if
+                    // it wants to append a semicolon, or something.
+                    if (this.scrubNakedValue) {
+                        line = this.scrubNakedValue(line[0]);
+                    }
                 }
-            }
-            if (line) {
-                if (block.opcode === 'procedures_definition') {
-                    proceduresCodes.push(line);
-                } else {
-                    codes.push(line);
+                if (line) {
+                    if (block.opcode === 'procedures_definition') {
+                        proceduresCodes.push(line);
+                    } else {
+                        codes.push(line);
+                    }
                 }
+            });
+            // Blank line between each section.
+            code = proceduresCodes.join('\n');
+            if (proceduresCodes.length > 0) {
+                code += '\n';
             }
-        });
-        // Blank line between each section.
-        let code = proceduresCodes.join('\n');
-        if (proceduresCodes.length > 0) {
-            code += '\n';
+            code += codes.join('\n');
         }
-        code += codes.join('\n');
 
         code = this.finish(code, options);
 

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -686,6 +686,41 @@ const myBlocks = function () {
     `;
 };
 
+ScratchBlocks.Msg.CATEGORY_RUBY = 'Ruby';
+ScratchBlocks.ScratchMsgs.locales.en.CATEGORY_RUBY = 'Ruby';
+ScratchBlocks.ScratchMsgs.locales.ja.CATEGORY_RUBY = 'ルビー';
+ScratchBlocks.ScratchMsgs.locales['ja-Hira'].CATEGORY_RUBY = 'ルビー';
+
+const ruby = function () {
+    return `
+    <category
+        name="%{BKY_CATEGORY_RUBY}"
+        id="ruby"
+        colour="#CC0043"
+        secondaryColour="#FF4D6A">
+        <block type="ruby_statement">
+            <value name="STATEMENT">
+                <shadow type="text">
+                    <field name="TEXT"></field>
+                </shadow>
+            </value>
+        </block>
+        <block type="ruby_statement_with_block">
+            <value name="STATEMENT">
+                <shadow type="text">
+                    <field name="TEXT"></field>
+                </shadow>
+            </value>
+            <value name="ARGS">
+                <shadow type="text">
+                    <field name="TEXT"></field>
+                </shadow>
+            </value>
+        </block>
+    </category>
+    `;
+};
+
 const xmlOpen = '<xml style="display: none">';
 const xmlClose = '</xml>';
 
@@ -708,7 +743,8 @@ const makeToolboxXML = function (isStage, targetId, categoriesXML) {
         sensing(isStage, targetId), gap,
         operators(isStage, targetId), gap,
         variables(isStage, targetId), gap,
-        myBlocks(isStage, targetId)
+        myBlocks(isStage, targetId), gap,
+        ruby(isStage, targetId)
     ];
 
     if (categoriesXML) {

--- a/src/lib/ruby-generator/event.js
+++ b/src/lib/ruby-generator/event.js
@@ -36,7 +36,7 @@ export default function (Generator) {
     Generator.event_whenbroadcastreceived = function (block) {
         block.isStatement = true;
         const message = Generator.getFieldValue(block, 'BROADCAST_OPTION');
-        return `${Generator.spriteName()}.when(receive:, ${Generator.quote_(message)}) do\n`;
+        return `${Generator.spriteName()}.when(:receive, ${Generator.quote_(message)}) do\n`;
     };
 
     Generator.event_broadcast = function (block) {

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -15,6 +15,7 @@ import SensingBlocks from './sensing.js';
 import OperatorsBlocks from './operators.js';
 import DataBlocks from './data.js';
 import ProcedureBlocks from './procedure.js';
+import RubyBlocks from './ruby.js';
 
 const SCALAR_TYPE = '';
 const LIST_TYPE = 'list';
@@ -431,5 +432,6 @@ SensingBlocks(RubyGenerator);
 OperatorsBlocks(RubyGenerator);
 DataBlocks(RubyGenerator);
 ProcedureBlocks(RubyGenerator);
+RubyBlocks(RubyGenerator);
 
 export default RubyGenerator;

--- a/src/lib/ruby-generator/ruby.js
+++ b/src/lib/ruby-generator/ruby.js
@@ -1,0 +1,34 @@
+/**
+ * Define Ruby code generator for Ruby Blocks
+ * @param {RubyGenerator} Generator The RubyGenerator
+ * @return {RubyGenerator} same as param.
+ */
+export default function (Generator) {
+    const getUnquoteText = function (block, fieldName, order) {
+        const input = block.inputs[fieldName];
+        if (input) {
+            const targetBlock = Generator.getBlock(input.block);
+            if (targetBlock && targetBlock.opcode === 'text') {
+                return Generator.getFieldValue(targetBlock, 'TEXT') || '';
+            }
+        }
+        return Generator.valueToCode(block, fieldName, order);
+    };
+
+    Generator.ruby_statement = function (block) {
+        const statement = getUnquoteText(block, 'STATEMENT', Generator.ORDER_NONE);
+        return `${statement}\n`;
+    };
+
+    Generator.ruby_statement_with_block = function (block) {
+        const statement = getUnquoteText(block, 'STATEMENT', Generator.ORDER_NONE);
+        let args = getUnquoteText(block, 'ARGS', Generator.ORDER_NONE);
+        if (args.length > 0) {
+            args = ` ${args}`;
+        }
+        const branch = Generator.statementToCode(block, 'SUBSTACK') || '';
+        return `${statement} do${args}\n${branch}end\n`;
+    };
+
+    return Generator;
+}

--- a/src/lib/ruby-parser.js
+++ b/src/lib/ruby-parser.js
@@ -1,0 +1,67 @@
+/* global Opal */
+Opal.load('opal');
+Opal.load('opal-parser');
+Opal.load('parser');
+Opal.load('parser/ruby23');
+
+// HACK: monkey patch to get Parser::SyntaxError exception
+Opal.eval(`
+module Parser
+  module Source
+    class Buffer
+      def source_lines
+        @lines ||= begin
+          lines = @source.lines.to_a
+          lines << ''.dup if @source.end_with?("\n".freeze)
+
+          lines = lines.map do |line|
+            line = line.chomp("\n".freeze)
+            line.freeze
+            line
+          end
+
+          lines.freeze
+        end
+      end
+    end
+  end
+end
+
+module Parser
+  class Diagnostic
+    def render_line(range, ellipsis=false, range_end=false)
+      source_line    = range.source_line
+      highlight_line = ' ' * source_line.length
+
+      @highlights.each do |highlight|
+       line_range = range.source_buffer.line_range(range.line)
+        if highlight = highlight.intersect(line_range)
+          highlight_line[highlight.column_range] = '~' * highlight.size
+        end
+      end
+
+      if range.is?("\n")
+        highlight_line += "^"
+      else
+        if !range_end && range.size >= 1
+          s = '^' + '~' * (range.size - 1)
+        else
+          s = '~' * range.size
+        end
+        end_pos = range.column_range.end
+        if !range.column_range.exclude_end?
+          end_pos += 1
+        end
+        highlight_line = highlight_line[0...range.column_range.begin] + s + highlight_line[end_pos..-1]
+      end
+
+      highlight_line += '...' if ellipsis
+
+      [source_line, highlight_line].
+        map { |line| "#{range.source_buffer.name}:#{range.line}: #{line}" }
+    end
+  end
+end
+`);
+
+export default Opal.Parser.Ruby23;

--- a/src/lib/ruby-to-blocks-converter-hoc.jsx
+++ b/src/lib/ruby-to-blocks-converter-hoc.jsx
@@ -1,0 +1,122 @@
+import bindAll from 'lodash.bindall';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import VM from 'scratch-vm';
+import {targetCodeToBlocks} from '../lib/ruby-to-blocks-converter';
+
+import {
+    activateTab,
+    RUBY_TAB_INDEX
+} from '../reducers/editor-tab';
+import {showStandardAlert} from '../reducers/alerts';
+import {highlightTarget} from '../reducers/targets';
+import {
+    rubyCodeShape,
+    updateRubyCodeErrors,
+    convertedRubyCode
+} from '../reducers/ruby-code';
+
+
+/**
+ * Higher Order Component to provide behavior for converting Ruby to Code.
+ * @param {React.Component} WrappedComponent the component to add Ruby to Code converting functionality to
+ * @returns {React.Component} WrappedComponent with Ruby to Code converting functionality added
+ *
+ * <ProjectSaverHOC>
+ *     <WrappedComponent />
+ * </ProjectSaverHOC>
+ */
+const RubyToBlocksConverterHOC = function (WrappedComponent) {
+    class RubyToBlocksConverterComponent extends React.Component {
+        constructor (props) {
+            super(props);
+            bindAll(this, [
+                'targetCodeToBlocks'
+            ]);
+        }
+
+        /**
+         * targetCodeToBlocks:
+         * @return {boolean} - True if succeeded to convert Ruby to Blocks
+         */
+        targetCodeToBlocks () {
+            if (this.props.rubyCode.modified) {
+                const errors = [];
+                if (!targetCodeToBlocks(this.props.vm, this.props.rubyCode.target, this.props.rubyCode.code, errors)) {
+                    this.props.vm.setEditingTarget(this.props.rubyCode.target.id);
+                    if (!this.props.rubyCode.target.isStage) {
+                        this.props.onHighlightTarget(this.props.rubyCode.target.id);
+                    }
+                    this.props.onActivateRubyTab();
+                    this.props.onShowConvertRubyToBlocksErrorAlert();
+                    this.props.updateRubyCodeErrorsState(errors);
+                    return false;
+                }
+                this.props.convertedRubyCodeState();
+            }
+            return true;
+        }
+
+        render () {
+            const {
+                /* eslint-disable no-unused-vars */
+                editingTarget,
+                convertedRubyCodeState,
+                onActivateRubyTab,
+                onHighlightTarget,
+                onShowConvertRubyToBlocksErrorAlert,
+                rubyCode,
+                updateRubyCodeErrorsState,
+                /* eslint-enable no-unused-vars */
+                ...componentProps
+            } = this.props;
+            return (
+                <WrappedComponent
+                    targetCodeToBlocks={this.targetCodeToBlocks}
+                    {...componentProps}
+                />
+            );
+        }
+    }
+
+    RubyToBlocksConverterComponent.propTypes = {
+        convertedRubyCodeState: PropTypes.func,
+        editingTarget: PropTypes.string,
+        onActivateRubyTab: PropTypes.func,
+        onHighlightTarget: PropTypes.func,
+        onShowConvertRubyToBlocksErrorAlert: PropTypes.func,
+        rubyCode: rubyCodeShape,
+        updateRubyCodeErrorsState: PropTypes.func,
+        vm: PropTypes.instanceOf(VM)
+    };
+
+    const mapStateToProps = state => ({
+        editingTarget: state.scratchGui.targets.editingTarget,
+        rubyCode: state.scratchGui.rubyCode,
+        vm: state.scratchGui.vm
+    });
+
+    const mapDispatchToProps = dispatch => ({
+        convertedRubyCodeState: () => dispatch(convertedRubyCode()),
+        onActivateRubyTab: () => dispatch(activateTab(RUBY_TAB_INDEX)),
+        onHighlightTarget: id => dispatch(highlightTarget(id)),
+        onShowConvertRubyToBlocksErrorAlert: () => dispatch(showStandardAlert('convertRubyToBlocksError')),
+        updateRubyCodeErrorsState: errors => dispatch(updateRubyCodeErrors(errors))
+    });
+
+    // Allow incoming props to override redux-provided props. Used to mock in tests.
+    const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(
+        {}, stateProps, dispatchProps, ownProps
+    );
+
+    return connect(
+        mapStateToProps,
+        mapDispatchToProps,
+        mergeProps
+    )(RubyToBlocksConverterComponent);
+};
+
+export {
+    RubyToBlocksConverterHOC as default
+};

--- a/src/lib/ruby-to-blocks-converter/.eslintrc.js
+++ b/src/lib/ruby-to-blocks-converter/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    extends: ['../../.eslintrc.js'],
+    rules: {
+        'eqeqeq': 0
+    }
+};

--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -1,0 +1,676 @@
+/* global Opal */
+import _ from 'lodash';
+import log from '../log';
+import Blockly from 'scratch-blocks';
+import RubyParser from '../ruby-parser';
+
+/**
+ * Class for Ruby's self for detecting self.
+ */
+class Self {}
+
+/**
+ * Exception class for RubyToBlocksConverter
+ */
+class RubyToBlocksConverterError {
+    constructor (node, message) {
+        this.node = node;
+        this.message = message;
+    }
+}
+
+/**
+ * Class for a block converter that translates ruby code into the blocks.
+ */
+class RubyToBlocksConverter {
+    constructor (vm) {
+        this.vm = vm;
+        this.reset();
+    }
+
+    get errors () {
+        return this._context.errors;
+    }
+
+    get blocks () {
+        return this._context.blocks;
+    }
+
+    reset () {
+        this._context = {
+            blocks: {},
+            blockTypes: {},
+            currentNode: null,
+            errors: []
+        };
+    }
+
+    targetCodeToBlocks (target, code) {
+        this.reset();
+        try {
+            const root = RubyParser.$parse(code);
+            let blocks = this._process(root);
+            if (!_.isArray(blocks)) {
+                blocks = [blocks];
+            }
+            let prevBlock;
+            blocks.forEach(block => {
+                if (!block) {
+                    return;
+                }
+                if (!prevBlock) {
+                    block.topLevel = true;
+                }
+                if (block.next) {
+                    prevBlock = block;
+                } else {
+                    prevBlock = null;
+                }
+            });
+            return true;
+        } catch (e) {
+            let error;
+            if (e.$$class && e.$$class.$$name === 'SyntaxError') {
+                const loc = e.$diagnostic().$location();
+                error = this._toErrorAnnotation(loc.$line(), loc.$column(), e.$message());
+            } else if (e instanceof RubyToBlocksConverterError) {
+                const loc = e.node.$loc();
+                error = this._toErrorAnnotation(loc.$line(), loc.$column(), e.message);
+            } else if (this._context.currentNode) {
+                const loc = this._context.currentNode.$loc();
+                error = this._toErrorAnnotation(loc.$line(), loc.$column(), e.message);
+            } else {
+                error = this._toErrorAnnotation(1, 0, e.message);
+            }
+            if (error) {
+                this._context.errors.push(error);
+            }
+            return false;
+        }
+    }
+
+    _toErrorAnnotation (row, column, message) {
+        if (row === Opal.nil) {
+            row = 0;
+        } else {
+            row -= 1;
+        }
+        let columnText = '';
+        if (column === Opal.nil) {
+            column = 0;
+        } else {
+            columnText = `${column}: `;
+        }
+        return {
+            row: row,
+            column: column,
+            type: 'error',
+            text: `${columnText}${message}`
+        };
+    }
+
+    applyTargetBlocks (target, blocks) {
+        Object.keys(target.blocks._blocks).forEach(blockId => {
+            target.blocks.deleteBlock(blockId);
+        });
+        Object.keys(blocks).forEach(blockId => {
+            target.blocks.createBlock(blocks[blockId]);
+        });
+        this.vm.emitWorkspaceUpdate();
+    }
+
+    _checkNumChildren (node, length) {
+        if (_.isArray(length)) {
+            if (length.indexOf(node.children.length) < 0) {
+                log.error(`'${node.type}' node.children.length !== ${length.join(' or ')}: `, node.children);
+            }
+        } else if (node.children.length !== length) {
+            log.error(`'${node.type}' node.children.length !== ${length}: `, node.children);
+        }
+    }
+
+    _createBlock (opcode, type, attributes = {}) {
+        const block = Object.assign({
+            id: Blockly.utils.genUid(),
+            opcode: opcode,
+            inputs: {},
+            fields: {},
+            next: null,
+            topLevel: false,
+            parent: null,
+            shadow: false,
+            x: void 0,
+            y: void 0
+        }, attributes);
+        this._context.blocks[block.id] = block;
+        this._context.blockTypes[block.id] = type;
+        return block;
+    }
+
+    _createFieldBlock (opcode, fieldName, value, parentBlockId) {
+        return this._createBlock(opcode, 'value', {
+            fields: {
+                [fieldName]: {
+                    name: fieldName,
+                    id: void 0,
+                    value: value
+                }
+            },
+            parent: parentBlockId,
+            shadow: true
+        });
+    }
+
+    _createTextBlock (value, parentBlockId) {
+        if (_.isString(value)) {
+            return this._createFieldBlock('text', 'TEXT', value, parentBlockId);
+        }
+        return value;
+    }
+
+    _createNumberBlock (opcode, value, parentBlockId) {
+        if (_.isNumber(value)) {
+            return this._createFieldBlock(opcode, 'NUM', value, parentBlockId);
+        }
+        return value;
+    }
+
+    _addInput (block, name, inputBlock) {
+        block.inputs[name] = {
+            name: name,
+            block: inputBlock.id,
+            shadow: inputBlock.shadow ? inputBlock.id : null
+        };
+    }
+
+    _addSubstack (block, substackBlocks, num = 1) {
+        let name = 'SUBSTACK';
+        if (num > 1) {
+            name = `${name}${num}`;
+        }
+        block.inputs[name] = {
+            name: name,
+            block: substackBlocks.length > 0 ? substackBlocks[0].id : null,
+            shadow: null
+        };
+        substackBlocks.forEach(b => {
+            b.parent = block.id;
+        });
+    }
+
+    _getSource (node) {
+        const expression = node.$loc().$expression();
+        if (expression === Opal.nil) {
+            return '';
+        }
+        return expression.$source().toString();
+    }
+
+    _popWaitBlock (blocks) {
+        if (!blocks || !_.isArray(blocks)) {
+            return null;
+        }
+
+        const block = _.last(blocks);
+        if (block.opcode === 'ruby_statement') {
+            const textBlock = this._context.blocks[block.inputs.STATEMENT.block];
+            if (textBlock.fields.TEXT.value === 'wait') {
+                blocks.pop();
+                if (blocks.length > 0) {
+                    _.last(blocks).next = null;
+                }
+                delete this._context.blocks[block.id];
+                delete this._context.blocks[block.id];
+
+                return block;
+            }
+        }
+        return null;
+    }
+
+    _blockType (block) {
+        return this._context.blockTypes[block.id];
+    }
+
+    _process (node) {
+        if (!node) {
+            return null;
+        }
+        if (node == Opal.nil) {
+            return Opal.nil;
+        }
+        node = node.$to_ast();
+        this._context.currentNode = node;
+        const handlerName = '_' + _.camelCase(`on_${node.type}`); // eslint-disable-line prefer-template
+        if (_.isFunction(this[handlerName])) {
+            return this[handlerName](node);
+        }
+        throw new RubyToBlocksConverterError(node, `not supported node type: ${node.type}`);
+    }
+
+    _onBegin (node) {
+        let prevBlock = null;
+        const blocks = [];
+        let terminated = false;
+        node.children.forEach(childNode => {
+            const block = this._process(childNode);
+            if (!block) {
+                return;
+            }
+            switch (this._blockType(block)) {
+            case 'statement':
+                if (prevBlock) {
+                    prevBlock.next = block.id;
+                }
+                prevBlock = block;
+                if (!terminated) {
+                    blocks.push(block);
+                }
+                break;
+            case 'value':
+                block.topLevel = true;
+                break;
+            case 'hat':
+                break;
+            case 'terminate':
+                if (prevBlock) {
+                    prevBlock.next = block.id;
+                }
+                prevBlock = null;
+                if (!terminated) {
+                    blocks.push(block);
+                }
+                terminated = true;
+                break;
+            }
+            return block;
+        });
+        return blocks;
+    }
+
+    _onBlock (node) {
+        this._checkNumChildren(node, 3);
+
+        return this._onSend(node.children[0], node.children[1], node.children[2]);
+    }
+
+    _onSend (node, rubyBlockArgsNode, rubyBlockNode) {
+        // 対象外のコードの場合に備えて、作成したブロックを削除できるようにしておく。
+        const savedBlockIds = Object.keys(this._context.blocks);
+
+        const receiver = this._process(node.children[0]);
+        const name = node.children[1].toString();
+        const args = node.children.slice(2).map(childNode => this._process(childNode));
+
+        let rubyBlockArgs;
+        if (rubyBlockArgsNode) {
+            rubyBlockArgs = this._process(rubyBlockArgsNode);
+        }
+
+        const receiverAndArgsBlockIds = Object.keys(this._context.blocks).filter(i => savedBlockIds.indexOf(i) < 0);
+
+        let rubyBlock;
+        if (rubyBlockNode) {
+            rubyBlock = this._process(rubyBlockNode);
+            if (!_.isArray(rubyBlock)) {
+                rubyBlock = [rubyBlock];
+            }
+        }
+
+        let block;
+        if (receiver === Self || receiver == Opal.nil) {
+            switch (name) {
+            case 'move':
+                if (args.length == 1) {
+                    block = this._createBlock('motion_movesteps', 'statement');
+                    this._addInput(block, 'STEPS', this._createNumberBlock('math_number', args[0], block.id));
+                }
+                break;
+            case 'turn_right':
+            case 'turn_left':
+                if (args.length == 1) {
+                    block = this._createBlock(
+                        name === 'turn_right' ? 'motion_turnright' : 'motion_turnleft', 'statement'
+                    );
+                    this._addInput(block, 'DEGREES', this._createNumberBlock('math_number', args[0], block.id));
+                }
+                break;
+            case 'go_to':
+                if (args.length == 1) {
+                    if (_.isString(args[0])) {
+                        block = this._createBlock('motion_goto', 'statement');
+                        this._addInput(
+                            block,
+                            'TO',
+                            this._createFieldBlock('motion_goto_menu', 'TO', args[0], block.id)
+                        );
+                    } else if (_.isArray(args[0]) && args[0].length == 2) {
+                        block = this._createBlock('motion_gotoxy', 'statement');
+                        this._addInput(block, 'X', this._createNumberBlock('math_number', args[0][0], block.id));
+                        this._addInput(block, 'Y', this._createNumberBlock('math_number', args[0][1], block.id));
+                    }
+                }
+                break;
+            case 'glide':
+                if (args.length == 2 && args[1] instanceof Map && args[1].size === 1 && args[1].get('secs')) {
+                    if (_.isString(args[0])) {
+                        block = this._createBlock('motion_glideto', 'statement');
+                        this._addInput(
+                            block,
+                            'TO',
+                            this._createFieldBlock('motion_glideto_menu', 'TO', args[0], block.id)
+                        );
+                    } else if (_.isArray(args[0]) && args[0].length == 2) {
+                        block = this._createBlock('motion_glidesecstoxy', 'statement');
+                        this._addInput(block, 'X', this._createNumberBlock('math_number', args[0][0], block.id));
+                        this._addInput(block, 'Y', this._createNumberBlock('math_number', args[0][1], block.id));
+                    }
+                    this._addInput(
+                        block,
+                        'SECS',
+                        this._createNumberBlock('math_number', args[1].get('secs'), block.id)
+                    );
+                }
+                break;
+            case 'direction=':
+                if (args.length == 1) {
+                    block = this._createBlock('motion_pointindirection', 'statement');
+                    this._addInput(block, 'DIRECTION', this._createNumberBlock('math_angle', args[0], block.id));
+                }
+                break;
+            case 'point_towards':
+                if (args.length == 1) {
+                    if (_.isString(args[0])) {
+                        block = this._createBlock('motion_pointtowards', 'statement');
+                        this._addInput(
+                            block,
+                            'TOWARDS',
+                            this._createFieldBlock('motion_pointtowards_menu', 'TOWARDS', args[0], block.id)
+                        );
+                    }
+                }
+                break;
+            case 'bounce_if_on_edge':
+                if (args.length == 0) {
+                    block = this._createBlock('motion_ifonedgebounce', 'statement');
+                }
+                break;
+            case 'rotation_style=':
+                if (args.length == 1 && _.isString(args[0])) {
+                    block = this._createBlock('motion_setrotationstyle', 'statement', {
+                        fields: {
+                            STYLE: {
+                                name: 'STYLE',
+                                id: void 0,
+                                value: args[0]
+                            }
+                        }
+                    });
+                }
+                break;
+            case 'x=':
+            case 'y=':
+                if (args.length == 1) {
+                    let xy;
+                    if (name === 'x=') {
+                        xy = 'x';
+                    } else {
+                        xy = 'y';
+                    }
+                    block = this._createBlock(`motion_set${xy}`, 'statement');
+                    this._addInput(block, _.toUpper(xy), this._createNumberBlock('math_number', args[0], block.id));
+                }
+                break;
+            case 'x':
+            case 'y':
+                if (args.length == 0) {
+                    let xy;
+                    if (name === 'x=') {
+                        xy = 'x';
+                    } else {
+                        xy = 'y';
+                    }
+                    block = this._createBlock(`motion_${xy}position`, 'value');
+                }
+                break;
+            case 'direction':
+                if (args.length == 0) {
+                    block = this._createBlock('motion_direction', 'value');
+                }
+                break;
+            case 'when':
+                if (args.length === 1) {
+                    if (args[0] == 'flag_clicked' &&
+                        rubyBlockArgs && rubyBlockArgs.length == 0 && rubyBlock.length > 0) {
+                        block = this._createBlock('event_whenflagclicked', 'hat', {
+                            topLevel: true
+                        });
+
+                        if (rubyBlock[0] !== Opal.nil) {
+                            rubyBlock.forEach(b => {
+                                b.parent = block.id;
+                            });
+                            block.next = rubyBlock[0].id;
+                        }
+                    }
+                }
+                break;
+            case 'loop':
+                if (args.length == 0) {
+                    const waitBlock = this._popWaitBlock(rubyBlock);
+                    if (waitBlock) {
+                        block = this._createBlock('control_forever', 'statement');
+                        this._addSubstack(block, rubyBlock);
+                    }
+                }
+                break;
+            case 'touching?':
+                if (args.length == 1 && _.isString(args[0])) {
+                    block = this._createBlock('sensing_touchingobject', 'value');
+                    this._addInput(
+                        block,
+                        'TOUCHINGOBJECTMENU',
+                        this._createFieldBlock('sensing_touchingobjectmenu', 'TOUCHINGOBJECTMENU', args[0], block.id)
+                    );
+                }
+                break;
+
+            }
+        }
+        if (!block) {
+            receiverAndArgsBlockIds.forEach(blockId => {
+                delete this._context.blocks[blockId];
+            });
+
+            if (rubyBlock) {
+                block = this._createBlock('ruby_statement_with_block', 'statement');
+                this._addInput(block, 'STATEMENT', this._createTextBlock(this._getSource(node), block.id));
+                this._addInput(block, 'ARGS', this._createTextBlock(this._getSource(rubyBlockArgsNode), block.id));
+                this._addSubstack(block, rubyBlock);
+            } else {
+                block = this._createBlock('ruby_statement', 'statement');
+                this._addInput(block, 'STATEMENT', this._createTextBlock(this._getSource(node), block.id));
+            }
+        }
+        return block;
+    }
+
+    _onSelf (node) { // eslint-disable-line no-unused-vars
+        return Self;
+    }
+
+    _onSym (node) {
+        this._checkNumChildren(node, 1);
+
+        return node.children[0].toString();
+    }
+
+    _onArgs (node) {
+        return node.children.map(childNode => this._process(childNode));
+    }
+
+    _onArg (node) {
+        this._checkNumChildren(node, 1);
+
+        return node.children[0];
+    }
+
+    _onInt (node) {
+        this._checkNumChildren(node, 1);
+
+        return node.children[0];
+    }
+
+    _onIf (node) {
+        this._checkNumChildren(node, 3);
+
+        const cond = this._process(node.children[0]);
+        let statement = this._process(node.children[1]);
+        if (!_.isArray(statement)) {
+            statement = [statement];
+        }
+        let elseStatement = this._process(node.children[2]);
+        if (!_.isArray(elseStatement)) {
+            elseStatement = [elseStatement];
+        }
+
+        let block;
+        if (elseStatement[0] === Opal.nil) {
+            block = this._createBlock('control_if', 'statement', {
+                inputs: {
+                    CONDITION: {
+                        name: 'CONDITION',
+                        block: cond.id,
+                        shadow: null
+                    },
+                    SUBSTACK: {
+                        name: 'SUBSTACK',
+                        block: statement[0] === Opal.nil ? null : statement[0].id,
+                        shadow: null
+                    }
+                }
+            });
+        } else {
+            block = this._createBlock('control_if_else', 'statement', {
+                inputs: {
+                    CONDITION: {
+                        name: 'CONDITION',
+                        block: cond.id,
+                        shadow: null
+                    },
+                    SUBSTACK: {
+                        name: 'SUBSTACK',
+                        block: statement[0] === Opal.nil ? null : statement[0].id,
+                        shadow: null
+                    },
+                    SUBSTACK2: {
+                        name: 'SUBSTACK2',
+                        block: elseStatement[0].id,
+                        shadow: null
+                    }
+                }
+            });
+        }
+        cond.parent = block.id;
+        statement.forEach(b => {
+            if (b && b !== Opal.nil) {
+                b.parent = block.id;
+            }
+        });
+        elseStatement.forEach(b => {
+            if (b && b !== Opal.nil) {
+                b.parent = block.id;
+            }
+        });
+        return block;
+    }
+
+    _onStr (node) {
+        this._checkNumChildren(node, 1);
+
+        return node.children[0].toString();
+    }
+
+    _onArray (node) {
+        return node.children.map(childNode => this._process(childNode));
+    }
+
+    _onHash (node) {
+        return new Map(node.children.map(childNode => this._process(childNode)));
+    }
+
+    _onPair (node) {
+        this._checkNumChildren(node, 2);
+
+        return node.children.map(childNode => this._process(childNode));
+    }
+
+    _onTrue (node) { // eslint-disable-line no-unused-vars
+        return true;
+    }
+
+    _onFalse (node) { // eslint-disable-line no-unused-vars
+        return false;
+    }
+
+    _onOpAsgn (node) {
+        this._checkNumChildren(node, 3);
+
+        const savedBlockIds = Object.keys(this._context.blocks);
+        const lh = this._process(node.children[0]);
+        const operand = node.children[1].toString();
+        const rh = this._process(node.children[2]);
+
+        let block;
+        if (lh.hasOwnProperty('opcode')) {
+            switch (lh.opcode) {
+            case 'motion_xposition':
+            case 'motion_yposition':
+                if (operand === '+') {
+                    delete this._context.blocks[lh.id];
+
+                    let xy;
+                    if (lh.opcode === 'motion_xposition') {
+                        xy = 'x';
+                    } else {
+                        xy = 'y';
+                    }
+
+                    block = this._createBlock(`motion_change${xy}by`, 'statement');
+                    this._addInput(block, `D${_.toUpper(xy)}`, this._createNumberBlock('math_number', rh, block.id));
+                }
+                break;
+            }
+        }
+        if (!block) {
+            Object.keys(this._context.blocks).filter(i => savedBlockIds.indexOf(i) < 0)
+                .forEach(blockId => {
+                    delete this._context.blocks[blockId];
+                });
+            block = this._createBlock('ruby_statement', 'statement');
+            this._addInput(block, 'STATEMENT', this._createTextBlock(this._getSource(node), block.id));
+        }
+        return block;
+    }
+
+    _onLvar (node) {
+        this._checkNumChildren(node, 1);
+
+        return node.children[0].toString();
+    }
+}
+
+const targetCodeToBlocks = function (vm, target, code, errors = []) {
+    const converter = new RubyToBlocksConverter(vm);
+    if (converter.targetCodeToBlocks(target, code)) {
+        converter.applyTargetBlocks(target, converter.blocks);
+        return true;
+    }
+    converter.errors.forEach(e => errors.push(e));
+    return false;
+};
+
+export {
+    RubyToBlocksConverter as default,
+    targetCodeToBlocks
+};

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -7,6 +7,8 @@ export default {
     "gui.smalruby3.previewInfo.invitation": "We're working on the next generation of Smalruby. We're excited for you to try it!",
     "gui.smalruby3.previewInfo.welcome": "Welcome to the Smalruby 3.0 Preview",
     'gui.smalruby3.menuBar.downloadRubyCodeToComputer': 'Download Ruby code to your computer',
+    "gui.smalruby3.menuBar.generateRubyFromCode": "Generate Ruby from Code",
     "gui.smalruby3.unsupportedBrowser.description": "We're very sorry, but Smalruby 3.0 does not support Internet Explorer, Vivaldi, Opera or Silk. We recommend trying a newer browser such as Google Chrome, Mozilla Firefox, or Microsoft Edge.",
-    "gui.smalruby3.webglModal.description": "Unfortunately it looks like your browser or computer {webGlLink}. This technology is needed for Smalruby 3.0 to run."
+    "gui.smalruby3.webglModal.description": "Unfortunately it looks like your browser or computer {webGlLink}. This technology is needed for Smalruby 3.0 to run.",
+    "gui.smalruby3.alerts.convertRubyToBlocksError": "Could not convert Ruby to Code. Please fix Ruby!"
 };

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -7,6 +7,8 @@ export default {
     'gui.smalruby3.previewInfo.invitation': 'わたしたちはじせだいのスモウルビーをかいはつちゅうです。おためしください!',
     'gui.smalruby3.previewInfo.welcome': 'スモウルビー3.0 プレビューばんにようこそ!',
     'gui.smalruby3.menuBar.downloadRubyCodeToComputer': 'コンピュータにルビーをほぞんする',
+    'gui.smalruby3.menuBar.generateRubyFromCode': 'ルビーからコードにへんかんします',
     'gui.smalruby3.unsupportedBrowser.description': 'もうしわけありません。スモウルビー3.0はインターネットエクスプローラ、ビヴァルディ、オペラ、シルクをサポートしていません。グーグル クローム、モジラ ファイアーフォックス、マイクロソフト エッジのようなあたらしいブラウザのりようをおすすめします。',
-    'gui.smalruby3.webglModal.description': 'ざんねんながら、ブラウザーやコンピューターが{webGlLink}ようです。このぎじゅつはスモウルビー3.0のじっこうにひっすです。'
+    'gui.smalruby3.webglModal.description': 'ざんねんながら、ブラウザーやコンピューターが{webGlLink}ようです。このぎじゅつはスモウルビー3.0のじっこうにひっすです。',
+    'gui.smalruby3.alerts.convertRubyToBlocksError': 'ルビーからコードにへんかんできませんでした。ルビーをなおしてください！'
 };

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -7,6 +7,8 @@ export default {
     'gui.smalruby3.previewInfo.invitation': '私たちは次世代のスモウルビーを開発中です。お試しください!',
     'gui.smalruby3.previewInfo.welcome': 'スモウルビー3.0 プレビュー版にようこそ!',
     'gui.smalruby3.menuBar.downloadRubyCodeToComputer': 'コンピュータにルビーを保存する',
+    'gui.smalruby3.menuBar.generateRubyFromCode': 'ルビーからコードに変換します',
     'gui.smalruby3.unsupportedBrowser.description': '申し訳ありません。スモウルビー3.0はInternet Explorer、Vivaldi、Opera、Silkをサポートしていません。Google Chrome、Mozilla Firefox、Microsoft Edgeのような新しいブラウザの利用をお勧めします。',
-    'gui.smalruby3.webglModal.description': '残念ながら、ブラウザーやコンピューターが{webGlLink}ようです。この技術はスモウルビー3.0の実行に必須です。'
+    'gui.smalruby3.webglModal.description': '残念ながら、ブラウザーやコンピューターが{webGlLink}ようです。この技術はスモウルビー3.0の実行に必須です。',
+    'gui.smalruby3.alerts.convertRubyToBlocksError': 'ルビーからコードに変換できませんでした。ルビーを修正してください！'
 };

--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -14,6 +14,8 @@
         </script>
         <!-- /Sentry -->
     <% } %>
+    <script src="//cdn.opalrb.com/opal/current/opal.min.js"></script>
+    <script src="//cdn.opalrb.com/opal/current/opal-parser.min.js"></script>
   </head>
   <body>
   </body>

--- a/src/reducers/ruby-code.js
+++ b/src/reducers/ruby-code.js
@@ -2,36 +2,81 @@ import PropTypes from 'prop-types';
 import RubyGenerator from '../lib/ruby-generator';
 
 const UPDATE_RUBYCODE = 'smalruby3-gui/ruby-code/UPDATE_RUBYCODE';
+const UPDATE_RUBYCODE_TARGET = 'smalruby3-gui/ruby-code/UPDATE_RUBYCODE_TARGET';
+const UPDATE_RUBYCODE_ERRORS = 'smalruby3-gui/ruby-code/UPDATE_RUBYCODE_ERRORS';
+const CONVERTED_RUBYCODE = 'smalruby3-gui/ruby-code/CONVERTED_RUBYCODE';
 
 const initialState = {
     target: null,
-    code: ''
+    code: '',
+    modified: false,
+    errors: []
 };
 
 const rubyCodeShape = PropTypes.shape({
     target: PropTypes.shape({
         id: PropTypes.string
     }),
-    code: PropTypes.string
+    code: PropTypes.string,
+    modified: PropTypes.bool,
+    errors: PropTypes.arrayOf(PropTypes.shape({
+        row: PropTypes.number,
+        type: PropTypes.oneOf(['error']),
+        text: PropTypes.string
+    }))
 });
 
 const reducer = function (state, action) {
     if (typeof state === 'undefined') state = initialState;
     switch (action.type) {
     case UPDATE_RUBYCODE:
-        return {
+        return Object.assign({}, state, {
+            code: action.code,
+            modified: true
+        });
+    case UPDATE_RUBYCODE_TARGET:
+        return Object.assign({}, state, {
             target: action.target,
-            code: RubyGenerator.targetToCode(action.target)
-        };
+            code: RubyGenerator.targetToCode(action.target),
+            modified: false
+        });
+    case UPDATE_RUBYCODE_ERRORS:
+        return Object.assign({}, state, {
+            errors: action.errors
+        });
+    case CONVERTED_RUBYCODE:
+        return Object.assign({}, state, {
+            modified: false
+        });
     default:
         return state;
     }
 };
 
-const updateRubyCode = function (target) {
+const updateRubyCode = function (code) {
     return {
         type: UPDATE_RUBYCODE,
+        code: code
+    };
+};
+
+const updateRubyCodeTarget = function (target) {
+    return {
+        type: UPDATE_RUBYCODE_TARGET,
         target: target
+    };
+};
+
+const updateRubyCodeErrors = function (errors) {
+    return {
+        type: UPDATE_RUBYCODE_ERRORS,
+        errors: errors
+    };
+};
+
+const convertedRubyCode = function () {
+    return {
+        type: CONVERTED_RUBYCODE
     };
 };
 
@@ -39,5 +84,8 @@ export {
     reducer as default,
     initialState as rubyCodeInitialState,
     rubyCodeShape,
-    updateRubyCode
+    updateRubyCode,
+    updateRubyCodeTarget,
+    updateRubyCodeErrors,
+    convertedRubyCode
 };


### PR DESCRIPTION
以下の作業を行う予定。

- [x] Rubyのコードを命令ブロックに変換できるようにするため、JavaScriptで実装したRubyの処理系 `Opal` を smalruby3-gui に組み込む
- [x] `Opal` と `parser` gem を使って、ブラウザ上でRubyのコードの構文解析ができる
    - `Opal.Parser.Ruby23.$parse(code)`
- [x] Rubyタブの読み取り専用を解除して、Rubyタブでコードを変更後、ユーザが指定したタイミング(メニューからRubyから命令ブロックに変換するものを選択する)で、Rubyコードから命令ブロックに変換できる。このタイミングでは、変換時にエラーが発生した場合は、コンソールにエラーを出力して、命令ブロックへの変換はまったく行わない。対象の命令ブロックの種類は、以下のみ。コメントも対象外。

```ruby
self.when(:flag_clicked) do
  loop do
    move(10)
    if touching?("_edge_")
      turn_right(180)
    end
    wait
  end
end
```

 - [x] Rubyタブでコード変更後のみ、コードタブ、フラッグを押す、スプライトを変更する、メニューから保存するを選択する、のときだけRubyから命令ブロックに変換する。
 - [x] Rubyタブでコード変更後にメニューからRubyをダウンロードすると、当該スプライトのみ、Rubyタブの内容を採用する
 - [x] コードタブを押したとき、スプライトを変更したときであれば、それぞれを変更させず、Rubyタグを表示したまま、スプライトは元のままとする。フラッグを押したときであれば、そもそも実行させない、それが無理ならすぐにストップする等して実行させない。メニューから保存するの場合は、ダイアログかなにかでエラーをユーザーにフィードバックする。
 - [x] Rubyタブから命令ブロックに変換するときに、エラーが発生すると、Rubyタブ中のエラーが発生したRubyコードの該当行にエラーを示すアイコンを表示する。
 - [x] Rubyタブでの修正がどうにもならないときのために、編集メニューに、コード→ルビーを用意する。これをおせば強制的にコードからルビーが生成されて、ルビーでの変更点が戻る。(ので、コードタブへの移動など、各種操作が可能になる)
 - [x] classやaliasのように未対応のsyntaxに遭遇したときに、いまはエラーログははくが、無視している。例外を挙げて、syntaxエラーのようにどの行が未対応なのかわかるようにする。