### PR TITLE
Rubyタブのエディタ部分の角を丸くしました

### DIFF
--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -19,7 +19,10 @@ const RubyTab = ({rubyCode}) => (
             showInvisibles: true
         }}
         style={{
-            fontFamily: ['Monaco', 'Menlo', 'Consolas', 'source-code-pro', 'monospace']
+            fontFamily: ['Monaco', 'Menlo', 'Consolas', 'source-code-pro', 'monospace'],
+            borderTopRightRadius: '0.5rem',
+            borderBottomRightRadius: '0.5rem',
+            border: '1px solid hsla(0, 0%, 0%, 0.15)'
         }}
         theme="clouds"
         value={rubyCode}


### PR DESCRIPTION
コードタブを参考にして、右上と右下のみを丸くしています。
最終的には、 containers ではなく components に定義したほうがいいでしょうね。
そうすると、 css でスタイルを指定できる。
