### PR TITLE
Dataの命令ブロックをRubyに変換できるようにしました

### DIFF
--- a/src/lib/ruby-generator/data.js
+++ b/src/lib/ruby-generator/data.js
@@ -1,0 +1,105 @@
+/**
+ * Define Ruby with Data Blocks
+ * @param {Blockly} Blockly The ScratchBlocks
+ * @return {Blockly} Blockly defined Ruby generator.
+ */
+export default function (Blockly) {
+    Blockly.Ruby.data_variable = function (block) {
+        const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
+        return [`${variable}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.data_setvariableto = function (block) {
+        const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
+        const value = Blockly.Ruby.valueToCode(block, 'VALUE', Blockly.Ruby.ORDER_NONE) || '0';
+        return `${variable} = ${value}\n`;
+    };
+
+    Blockly.Ruby.data_changevariableby = function (block) {
+        const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
+        const value = Blockly.Ruby.valueToCode(block, 'VALUE', Blockly.Ruby.ORDER_NONE) || 0;
+        return `${variable} += ${value}\n`;
+    };
+
+    Blockly.Ruby.data_showvariable = function (block) {
+        const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
+        return `show_variable(${variable})\n`;
+    };
+
+    Blockly.Ruby.data_hidevariable = function (block) {
+        const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
+        return `hide_variable(${variable})\n`;
+    };
+
+    Blockly.Ruby.data_listcontents = function (block) {
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return [`${list}`, Blockly.Ruby.ORDER_ATOMIC];
+    };
+
+    Blockly.Ruby.data_addtolist = function (block) {
+        const item = Blockly.Ruby.valueToCode(block, 'ITEM', Blockly.Ruby.ORDER_NONE) || '0';
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}.push(${item})\n`;
+    };
+
+    Blockly.Ruby.data_deleteoflist = function (block) {
+        const index = Blockly.Ruby.valueToCode(block, 'INDEX', Blockly.Ruby.ORDER_NONE) - 1 || 0;
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}.delete_at(${index})\n`;
+    };
+
+    Blockly.Ruby.data_deletealloflist = function (block) {
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}.clear\n`;
+    };
+
+    Blockly.Ruby.data_insertatlist = function (block) {
+        const index = Blockly.Ruby.valueToCode(block, 'INDEX', Blockly.Ruby.ORDER_NONE) - 1 || 0;
+        const item = Blockly.Ruby.valueToCode(block, 'ITEM', Blockly.Ruby.ORDER_NONE) || '0';
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}.insert(${index}, ${item})\n`;
+    };
+
+    Blockly.Ruby.data_replaceitemoflist = function (block) {
+        const index = Blockly.Ruby.valueToCode(block, 'INDEX', Blockly.Ruby.ORDER_INDEX) - 1 || 0;
+        const item = Blockly.Ruby.valueToCode(block, 'ITEM', Blockly.Ruby.ORDER_NONE) || '0';
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}[${index}] = ${item}\n`;
+    };
+
+    Blockly.Ruby.data_itemoflist = function (block) {
+        const index = Blockly.Ruby.valueToCode(block, 'INDEX', Blockly.Ruby.ORDER_INDEX) - 1 || 0;
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}[${index}]\n`;
+    };
+
+    Blockly.Ruby.data_itemnumoflist = function (block) {
+        const item = Blockly.Ruby.valueToCode(block, 'ITEM', Blockly.Ruby.ORDER_NONE) || '0';
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `${list}.index(${item})`;
+    };
+
+    Blockly.Ruby.data_lengthoflist = function (block) {
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return [`${list}.length`, Blockly.Ruby.ORDER_FUNCTION_CAL];
+    };
+
+    Blockly.Ruby.data_listcontainsitem = function (block) {
+        const order = Blockly.Ruby.ORDER_FUNCTION_CALL;
+        const item = Blockly.Ruby.valueToCode(block, 'ITEM', order) || '0';
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return [`${list}.include?(${item})`, order];
+    };
+
+    Blockly.Ruby.data_showlist = function (block) {
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `show_list(${list})\n`;
+    };
+
+    Blockly.Ruby.data_hidelist = function (block) {
+        const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
+        return `hide_list(${list})\n`;
+    };
+
+    return Blockly;
+}

--- a/src/lib/ruby-generator/data.js
+++ b/src/lib/ruby-generator/data.js
@@ -70,13 +70,13 @@ export default function (Blockly) {
     Blockly.Ruby.data_itemoflist = function (block) {
         const index = Blockly.Ruby.valueToCode(block, 'INDEX', Blockly.Ruby.ORDER_INDEX) - 1 || 0;
         const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
-        return `${list}[${index}]\n`;
+        return [`${list}[${index}]`, Blockly.Ruby.ORDER_FUNCTION_CAL];
     };
 
     Blockly.Ruby.data_itemnumoflist = function (block) {
         const item = Blockly.Ruby.valueToCode(block, 'ITEM', Blockly.Ruby.ORDER_NONE) || '0';
         const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
-        return `${list}.index(${item})`;
+        return [`${list}.index(${item})`, Blockly.Ruby.ORDER_FUNCTION_CAL];
     };
 
     Blockly.Ruby.data_lengthoflist = function (block) {

--- a/src/lib/ruby-generator/data.js
+++ b/src/lib/ruby-generator/data.js
@@ -6,7 +6,7 @@
 export default function (Blockly) {
     Blockly.Ruby.data_variable = function (block) {
         const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
-        return [`${variable}`, Blockly.Ruby.ORDER_ATOMIC];
+        return [variable, Blockly.Ruby.ORDER_ATOMIC];
     };
 
     Blockly.Ruby.data_setvariableto = function (block) {
@@ -23,17 +23,17 @@ export default function (Blockly) {
 
     Blockly.Ruby.data_showvariable = function (block) {
         const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
-        return `show_variable(${variable})\n`;
+        return `show_variable(${Blockly.Ruby.quote_(variable)})\n`;
     };
 
     Blockly.Ruby.data_hidevariable = function (block) {
         const variable = Blockly.Ruby.variableName(block.getFieldValue('VARIABLE'));
-        return `hide_variable(${variable})\n`;
+        return `hide_variable(${Blockly.Ruby.quote_(variable)})\n`;
     };
 
     Blockly.Ruby.data_listcontents = function (block) {
         const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
-        return [`${list}`, Blockly.Ruby.ORDER_ATOMIC];
+        return [list, Blockly.Ruby.ORDER_COLLECTION];
     };
 
     Blockly.Ruby.data_addtolist = function (block) {
@@ -93,12 +93,12 @@ export default function (Blockly) {
 
     Blockly.Ruby.data_showlist = function (block) {
         const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
-        return `show_list(${list})\n`;
+        return `show_list(${Blockly.Ruby.quote_(list)})\n`;
     };
 
     Blockly.Ruby.data_hidelist = function (block) {
         const list = Blockly.Ruby.listName(block.getFieldValue('LIST'));
-        return `hide_list(${list})\n`;
+        return `hide_list(${Blockly.Ruby.quote_(list)})\n`;
     };
 
     return Blockly;

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -9,6 +9,7 @@ import SoundBlocks from './sound.js';
 import EventBlocks from './event.js';
 import ControlBlocks from './control.js';
 import OperatorsBlocks from './operators.js';
+import DataBlocks from './data.js';
 
 /**
  * Define Ruby
@@ -344,6 +345,22 @@ export default function (Blockly) {
         return null;
     };
 
+    Blockly.Ruby.variableName = function (name) {
+        let variable = this.editingTarget.lookupOrCreateVariable(name);
+        if (variable) {
+            return variable.name;
+        }
+        return null;
+    };
+
+    Blockly.Ruby.listName = function (name) {
+        let list = this.editingTarget.lookupOrCreateList(name);
+        if (list) {
+            return list.name;
+        }
+        return null;
+    };
+
     Blockly.Ruby.workspaceToCode_ = Blockly.Ruby.workspaceToCode;
 
     Blockly.Ruby.workspaceToCode = function (block, target) {
@@ -392,6 +409,7 @@ export default function (Blockly) {
     Blockly = EventBlocks(Blockly);
     Blockly = ControlBlocks(Blockly);
     Blockly = OperatorsBlocks(Blockly);
+    Blockly = DataBlocks(Blockly);
 
     return Blockly;
 }

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -346,7 +346,7 @@ export default function (Blockly) {
     };
 
     Blockly.Ruby.variableName = function (name) {
-        let variable = this.editingTarget.lookupOrCreateVariable(name);
+        const variable = this.editingTarget.lookupOrCreateVariable(name);
         if (variable) {
             return variable.name;
         }
@@ -354,7 +354,7 @@ export default function (Blockly) {
     };
 
     Blockly.Ruby.listName = function (name) {
-        let list = this.editingTarget.lookupOrCreateList(name);
+        const list = this.editingTarget.lookupOrCreateList(name);
         if (list) {
             return list.name;
         }


### PR DESCRIPTION
命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-20 15-33-08](https://user-images.githubusercontent.com/23467008/47252344-25350680-d47e-11e8-9db2-cb18c0225faa.png) | ![screenshot from 2018-10-20 15-33-14](https://user-images.githubusercontent.com/23467008/47252345-28c88d80-d47e-11e8-997b-0cf29c269174.png)

現状だと、Arrayを定義する文が書けないため違和感のあるコードになっていまいます。
どこかで、`リスト = Array.new` みたいなものがどこかで欲しいなとは思いました