### PR TITLE
変数名として使えない文字を _ にエスケープする

### DIFF
--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -450,6 +450,9 @@ export default function (Blockly) {
         return null;
     };
 
+    const escapeIdentityRegexp =
+        /[\x00-\x1f\x7f-\x9f !"#$%&'()*+,-./:;<=>?@[\\\]^`{|}~]/g; // eslint-disable-line no-control-regex
+
     Blockly.Ruby.variableName = function (id, type = SCALAR_TYPE) {
         let currVar;
         let prefix;
@@ -470,7 +473,7 @@ export default function (Blockly) {
             }
         }
         if (currVar && currVar.type === type) {
-            return `${prefix}${currVar.name.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+            return `${prefix}${currVar.name.replace(escapeIdentityRegexp, '_')}`;
         }
         return null;
     };

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -470,7 +470,7 @@ export default function (Blockly) {
             }
         }
         if (currVar && currVar.type === type) {
-            return `${prefix}${currVar.name}`;
+            return `${prefix}${currVar.name.replace(/[^a-zA-Z0-9_]/g, '_')}`;
         }
         return null;
     };

--- a/test/unit/lib/ruby-generator.test.jsx
+++ b/test/unit/lib/ruby-generator.test.jsx
@@ -69,7 +69,16 @@ describe('RubyGenerator', () => {
                     id4: {
                         name: 'List2',
                         type: LIST_TYPE
-                    }
+                    },
+                    id2_1: {
+                        name: 'Avg(Total / Count)',
+                        type: SCALAR_TYPE
+                    },
+                    id2_2: {
+                        name: 'List of Symbols.',
+                        type: LIST_TYPE
+                    },
+
                 },
                 runtime: {
                     getTargetForStage: function () {
@@ -125,6 +134,14 @@ describe('RubyGenerator', () => {
             renderedTarget.isStage = true;
             expect(Ruby.variableName('id5')).toEqual(null);
             expect(Ruby.listName('id6')).toEqual(null);
+        });
+
+        test('escape except alphabet, number and _ to _', () => {
+            expect(Ruby.variableName('id2_1')).toEqual('@Avg_Total___Count_');
+            expect(Ruby.listName('id2_2')).toEqual('@List_of_Symbols_');
+            renderedTarget.isStage = true;
+            expect(Ruby.variableName('id2_1')).toEqual('$Avg_Total___Count_');
+            expect(Ruby.listName('id2_2')).toEqual('$List_of_Symbols_');
         });
     });
 

--- a/test/unit/lib/ruby-generator.test.jsx
+++ b/test/unit/lib/ruby-generator.test.jsx
@@ -77,8 +77,7 @@ describe('RubyGenerator', () => {
                     id2_2: {
                         name: 'List of Symbols.',
                         type: LIST_TYPE
-                    },
-
+                    }
                 },
                 runtime: {
                     getTargetForStage: function () {

--- a/test/unit/lib/ruby-generator.test.jsx
+++ b/test/unit/lib/ruby-generator.test.jsx
@@ -77,6 +77,18 @@ describe('RubyGenerator', () => {
                     id2_2: {
                         name: 'List of Symbols.',
                         type: LIST_TYPE
+                    },
+                    id2_3: {
+                        name: ' !"#$%&\'()*+,-./:;<=>?@[\\]^`{|}~]',
+                        type: SCALAR_TYPE
+                    },
+                    id2_4: {
+                        name: '平均(合計 / 件数)',
+                        type: SCALAR_TYPE
+                    },
+                    id2_5: {
+                        name: 'シンボル　配列。',
+                        type: LIST_TYPE
                     }
                 },
                 runtime: {
@@ -138,9 +150,21 @@ describe('RubyGenerator', () => {
         test('escape except alphabet, number and _ to _', () => {
             expect(Ruby.variableName('id2_1')).toEqual('@Avg_Total___Count_');
             expect(Ruby.listName('id2_2')).toEqual('@List_of_Symbols_');
+            expect(Ruby.variableName('id2_3')).toEqual('@_________________________________');
+
             renderedTarget.isStage = true;
             expect(Ruby.variableName('id2_1')).toEqual('$Avg_Total___Count_');
             expect(Ruby.listName('id2_2')).toEqual('$List_of_Symbols_');
+            expect(Ruby.variableName('id2_3')).toEqual('$_________________________________');
+        });
+
+        test('do not escape multibyte character like Japanese', () => {
+            expect(Ruby.variableName('id2_4')).toEqual('@平均_合計___件数_');
+            expect(Ruby.listName('id2_5')).toEqual('@シンボル　配列。');
+
+            renderedTarget.isStage = true;
+            expect(Ruby.variableName('id2_4')).toEqual('$平均_合計___件数_');
+            expect(Ruby.listName('id2_5')).toEqual('$シンボル　配列。');
         });
     });
 


### PR DESCRIPTION
refs #97