### PR TITLE
拡張機能のブロックを変換しようとした時はnullを返すようにします

### DIFF
--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import minilog from 'minilog';
 
 import GeneratedBlocks from './generated.js';
 import MathBlocks from './math.js';
@@ -495,6 +496,8 @@ export default function (Blockly) {
 
     Blockly.Ruby.blockToCode_ = Blockly.Ruby.blockToCode;
 
+    minilog.enable();
+    const log = minilog('ruby-generator');
     Blockly.Ruby.blockToCode = function (block) {
         if (block && !block.disabled && block.type.match(/^hardware_/)) {
             this.definitions_.prepare__init_hardware = 'init_hardware';
@@ -502,6 +505,7 @@ export default function (Blockly) {
         try {
             return this.blockToCode_(block);
         } catch (error) {
+            log.error(`'${block.type}' block is not unsupported to generate Ruby code. Please implement it.`);
             return null;
         }
     };

--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -499,7 +499,11 @@ export default function (Blockly) {
         if (block && !block.disabled && block.type.match(/^hardware_/)) {
             this.definitions_.prepare__init_hardware = 'init_hardware';
         }
-        return this.blockToCode_(block);
+        try {
+            return this.blockToCode_(block);
+        } catch (error) {
+            return null;
+        }
     };
 
     Blockly = GeneratedBlocks(Blockly);


### PR DESCRIPTION
#96 を対策しました

命令ブロック | Ruby
---- | ----
![screenshot from 2018-10-24 14-52-56](https://user-images.githubusercontent.com/23467008/47409169-ef08c700-d79c-11e8-99db-af97982b7dc5.png) | ![screenshot from 2018-10-24 14-53-29](https://user-images.githubusercontent.com/23467008/47409177-f4fea800-d79c-11e8-84b5-166c02cd23ff.png)

拡張ブロックの下にくっついているブロックは変換されないという仕様にはなってしまいます。
