### PR TITLE
コンピュータにルビーのコードを保存するの機能を実装しました

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "immutable": "3.8.2",
     "intl": "1.2.5",
     "jest": "^21.0.0",
+    "jszip": "3.1.5",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",
     "lodash.debounce": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "immutable": "3.8.2",
     "intl": "1.2.5",
     "jest": "^21.0.0",
-    "jszip": "3.1.5",
     "keymirror": "0.1.1",
     "lodash.bindall": "4.4.0",
     "lodash.debounce": "4.0.8",

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -379,7 +379,7 @@ class MenuBar extends React.Component {
                                             onClick={this.handleCloseFileMenuAndThen(downloadProject)}
                                         >
                                             <FormattedMessage
-                                                defaultMessage="Download Ruby code to your compute"
+                                                defaultMessage="Save Ruby code to your computer"
                                                 description="Menu bar item for downloading Ruby code to your computer"
                                                 id="gui.smalruby3.menuBar.downloadRubyCodeToComputer"
                                             />

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -17,6 +17,7 @@ import ProjectTitleInput from './project-title-input.jsx';
 import AccountNav from '../../containers/account-nav.jsx';
 import LoginDropdown from './login-dropdown.jsx';
 import SB3Downloader from '../../containers/sb3-downloader.jsx';
+import RubyDownloader from '../../containers/ruby-downloader.jsx';
 import DeletionRestorer from '../../containers/deletion-restorer.jsx';
 import TurboMode from '../../containers/turbo-mode.jsx';
 
@@ -373,18 +374,17 @@ class MenuBar extends React.Component {
                                             />
                                         </MenuItem>
                                     )}</SB3Downloader>
-                                    <MenuItemTooltip
-                                        id="download_ruby_code"
-                                        isRtl={this.props.isRtl}
-                                    >
-                                        <MenuItem>
+                                    <RubyDownloader>{downloadProject => (
+                                        <MenuItem
+                                            onClick={this.handleCloseFileMenuAndThen(downloadProject)}
+                                        >
                                             <FormattedMessage
-                                                defaultMessage="Download Ruby code to your computer"
+                                                defaultMessage="Download Ruby code to your compute"
                                                 description="Menu bar item for downloading Ruby code to your computer"
                                                 id="gui.smalruby3.menuBar.downloadRubyCodeToComputer"
                                             />
                                         </MenuItem>
-                                    </MenuItemTooltip>
+                                    )}</RubyDownloader>
                                 </MenuSection>
                             </MenuBarMenu>
                         </div>

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -14,7 +14,7 @@ class RubyDownloader extends React.Component {
     saveRuby () {
         const code = `require "smalruby3"\n\n${this.props.rubyCode}`;
         return new Blob([code], {
-            type: "text/x-ruby-script"
+            type: 'text/x-ruby-script'
         });
     }
     downloadProject () {

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -12,8 +12,10 @@ class RubyDownloader extends React.Component {
         ]);
     }
     saveRuby () {
-        const projectRuby = `require "smalruby3"\n\n${this.props.rubyCode}`;
-        return new Blob([projectRuby], {type: 'text/plain'});
+        const code = `require "smalruby3"\n\n${this.props.rubyCode}`;
+        return new Blob([code], {
+            type: "text/x-ruby-script"
+        });
     }
     downloadProject () {
         const downloadLink = document.createElement('a');

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -1,0 +1,87 @@
+import bindAll from 'lodash.bindall';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import JSZip from 'jszip';
+import {projectTitleInitialState} from '../reducers/project-title';
+
+class RubyDownloader extends React.Component {
+    constructor (props) {
+        super(props);
+        bindAll(this, [
+            'downloadProject'
+        ]);
+    }
+    saveRuby () {
+        const projectRuby = `require "smalruby"\n${this.props.rubyCode}`;
+        // TODO want to eventually move zip creation out of here, and perhaps
+        // into scratch-storage
+        const zip = new JSZip();
+
+        // Put everything in a zip file
+        zip.file('project.rb', projectRuby);
+
+        return zip.generateAsync({
+            type: 'blob',
+            compression: 'DEFLATE',
+            compressionOptions: {
+                level: 6 // Tradeoff between best speed (1) and best compression (9)
+            }
+        });
+    }
+    downloadProject () {
+        const downloadLink = document.createElement('a');
+        document.body.appendChild(downloadLink);
+
+        this.saveRuby().then(content => {
+            if (this.props.onSaveFinished) {
+                this.props.onSaveFinished();
+            }
+            // Use special ms version if available to get it working on Edge.
+            if (navigator.msSaveOrOpenBlob) {
+                navigator.msSaveOrOpenBlob(content, this.props.projectFilename);
+                return;
+            }
+
+            const url = window.URL.createObjectURL(content);
+            downloadLink.href = url;
+            downloadLink.download = this.props.projectFilename;
+            downloadLink.click();
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(downloadLink);
+        });
+    }
+    render () {
+        const {
+            children
+        } = this.props;
+        return children(
+            this.downloadProject
+        );
+    }
+}
+
+const getProjectFilename = (curTitle, defaultTitle) => {
+    let filenameTitle = curTitle;
+    if (!filenameTitle || filenameTitle.length === 0) {
+        filenameTitle = defaultTitle;
+    }
+    return `${filenameTitle.substring(0, 100)}.zip`;
+};
+
+RubyDownloader.propTypes = {
+    children: PropTypes.func,
+    onSaveFinished: PropTypes.func,
+    projectFilename: PropTypes.string,
+    rubyCode: PropTypes.string
+};
+
+const mapStateToProps = state => ({
+    projectFilename: getProjectFilename(state.scratchGui.projectTitle, projectTitleInitialState),
+    rubyCode: state.scratchGui.rubyCode.code
+});
+
+export default connect(
+    mapStateToProps,
+    () => ({}) // omit dispatch prop
+)(RubyDownloader);

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -2,7 +2,6 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import JSZip from 'jszip';
 import {projectTitleInitialState} from '../reducers/project-title';
 
 class RubyDownloader extends React.Component {
@@ -13,43 +12,29 @@ class RubyDownloader extends React.Component {
         ]);
     }
     saveRuby () {
-        const projectRuby = `require "smalruby"\n${this.props.rubyCode}`;
-        // TODO want to eventually move zip creation out of here, and perhaps
-        // into scratch-storage
-        const zip = new JSZip();
-
-        // Put everything in a zip file
-        zip.file('project.rb', projectRuby);
-
-        return zip.generateAsync({
-            type: 'blob',
-            compression: 'DEFLATE',
-            compressionOptions: {
-                level: 6 // Tradeoff between best speed (1) and best compression (9)
-            }
-        });
+        const projectRuby = `require "smalruby3"\n\n${this.props.rubyCode}`;
+        return new Blob([projectRuby], {type: 'text/plain'});
     }
     downloadProject () {
         const downloadLink = document.createElement('a');
         document.body.appendChild(downloadLink);
 
-        this.saveRuby().then(content => {
-            if (this.props.onSaveFinished) {
-                this.props.onSaveFinished();
-            }
-            // Use special ms version if available to get it working on Edge.
-            if (navigator.msSaveOrOpenBlob) {
-                navigator.msSaveOrOpenBlob(content, this.props.projectFilename);
-                return;
-            }
+        const content = this.saveRuby();
+        if (this.props.onSaveFinished) {
+            this.props.onSaveFinished();
+        }
+        // Use special ms version if available to get it working on Edge.
+        if (navigator.msSaveOrOpenBlob) {
+            navigator.msSaveOrOpenBlob(content, this.props.projectFilename);
+            return;
+        }
 
-            const url = window.URL.createObjectURL(content);
-            downloadLink.href = url;
-            downloadLink.download = this.props.projectFilename;
-            downloadLink.click();
-            window.URL.revokeObjectURL(url);
-            document.body.removeChild(downloadLink);
-        });
+        const url = window.URL.createObjectURL(content);
+        downloadLink.href = url;
+        downloadLink.download = this.props.projectFilename;
+        downloadLink.click();
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(downloadLink);
     }
     render () {
         const {
@@ -66,7 +51,7 @@ const getProjectFilename = (curTitle, defaultTitle) => {
     if (!filenameTitle || filenameTitle.length === 0) {
         filenameTitle = defaultTitle;
     }
-    return `${filenameTitle.substring(0, 100)}.zip`;
+    return `${filenameTitle.substring(0, 100)}.rb`;
 };
 
 RubyDownloader.propTypes = {


### PR DESCRIPTION
#112　の内容です。 
SB3Downloaderと同じように、zipファイルでダウンロードします。

rbファイルのダウンロードは、Google Chromeの場合警告がでるみたいですね。（参考までに）
![screenshot from 2018-10-29 11-39-10](https://user-images.githubusercontent.com/23467008/47626607-580e8700-db6f-11e8-94ba-1066cfc429f4.png)

ダウンロードしたファイルの中身の例

```ruby:スモウルビープロジェクト.rb
require "smalruby"
Sprite.new("スプライト1",
           costumes: [
             {
               asset_id: "01ae57fd339529445cb890978ef8a054",
               name: "コスチューム1",
               bitmap_resolution: 1,
               md5: "01ae57fd339529445cb890978ef8a054.svg",
               data_format: "svg",
               rotation_center_x: 47,
               rotation_center_y: 55
             }
           ]) do
  move(10)
end
```
