### PR TITLE
リストを変換できない不具合を修正

### DIFF
--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -317,6 +317,7 @@ class RubyToBlocksConverter {
         if (block.fields[before]) {
             block.fields[after] = block.fields[before];
             block.fields[after].name = after;
+            block.fields[after].variableType = varType;
             delete block.fields[before];
 
             const varName = block.fields[after].value;
@@ -668,7 +669,8 @@ class RubyToBlocksConverter {
                                 VARIABLE: {
                                     name: 'VARIABLE',
                                     id: variable.id,
-                                    value: variable.name
+                                    value: variable.name,
+                                    variableType: Variable.SCALAR_TYPE
                                 }
                             }
                         });
@@ -694,7 +696,8 @@ class RubyToBlocksConverter {
                                 LIST: {
                                     name: 'LIST',
                                     id: variable.id,
-                                    value: variable.name
+                                    value: variable.name,
+                                    variableType: Variable.LIST_TYPE
                                 }
                             }
                         });
@@ -1156,7 +1159,8 @@ class RubyToBlocksConverter {
                             VARIABLE: {
                                 name: 'VARIABLE',
                                 id: variable.id,
-                                value: variable.name
+                                value: variable.name,
+                                variableType: Variable.SCALAR_TYPE
                             }
                         }
                     });
@@ -1262,7 +1266,8 @@ class RubyToBlocksConverter {
                     [name]: {
                         name: name,
                         id: variable.id,
-                        value: variable.name
+                        value: variable.name,
+                        variableType: variable.type
                     }
                 }
             });
@@ -1294,7 +1299,8 @@ class RubyToBlocksConverter {
                     VARIABLE: {
                         name: 'VARIABLE',
                         id: variable.id,
-                        value: variable.name
+                        value: variable.name,
+                        variableType: Variable.SCALAR_TYPE
                     }
                 }
             });

--- a/test/helpers/expect-to-equal-blocks.js
+++ b/test/helpers/expect-to-equal-blocks.js
@@ -35,6 +35,7 @@ const expectToEqualFields = function (context, actualFields, expectedFieldsInfo)
                     expectedType = Variable.LIST_TYPE;
                 }
                 expect(variable.type).toEqual(expectedType);
+                expect(field).toHaveProperty('variableType', expectedType);
             } else {
                 expect(field.id).toEqual(void 0);
                 expect(field.value).toEqual(expectedField.value);


### PR DESCRIPTION
あとでリストのAPIを修正する予定ではあるが、いったんまともに変換できるようにした。
fieldにvariableTypeが指定されていなかったことが原因。

refs #134