### PR TITLE
拡張機能「microbit」 のコンバーターの追加

### DIFF
--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -61,11 +61,18 @@ const MicroBitConverter = {
                 break;
             case 'display_text':
                 if (args.length === 1 && this._isString(args[0])) {
-                    block = this._changeBlock(receiver, 'microbit_displayText', 'sentence');
+                    block = this._changeBlock(receiver, 'microbit_displayText', 'statement');
                     delete this._context.blocks[receiver.inputs.EXPRESSION.block];
                     delete receiver.inputs.EXPRESSION;
 
                     this._addTextInput(block, 'TEXT', args[0], 'Hello!');
+                }
+                break;
+            case 'clear_display':
+                if (args.length === 0) {
+                    block = this._changeBlock(receiver, 'microbit_displayClear', 'statement');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
                 }
                 break;
             }

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -85,6 +85,18 @@ const MicroBitConverter = {
                     delete receiver.inputs.EXPRESSION;
                 }
                 break;
+            case 'tilted?':
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._changeBlock(receiver, 'microbit_isTilted', 'value_boolean');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
+
+                    this._addFieldInput(
+                        block, 'DIRECTION', 'microbit_menu_tiltDirectionAny', 'tiltDirectionAny',
+                        args[0], 'any'
+                    )
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -36,6 +36,16 @@ const MicroBitConverter = {
                     this._setParent(rubyBlock, block);
                 }
                 break;
+            case 'microbit_tilted':
+                if (args.length === 2 && this._isString(args[1])) {
+                    block = this._createBlock('microbit_whenTilted', 'hat');
+                    this._addFieldInput(
+                        block, 'DIRECTION', 'microbit_menu_tiltDirectionAny', 'tiltDirectionAny',
+                        args[1], 'any'
+                    )
+                    this._setParent(rubyBlock, block);
+                }
+                break;
             }
         } else if (this._isSelf(receiver) || receiver === Opal.nil) {
             switch (name) {

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -26,6 +26,16 @@ const MicroBitConverter = {
                     this._setParent(rubyBlock, block);
                 }
                 break;
+            case 'microbit_gesture':
+                if (args.length === 2 && this._isString(args[1])) {
+                    block = this._createBlock('microbit_whenGesture', 'hat');
+                    this._addFieldInput(
+                        block, 'GESTURE', 'microbit_menu_gestures', 'gestures',
+                        args[1], 'moved'
+                    )
+                    this._setParent(rubyBlock, block);
+                }
+                break;
             }
         } else if (this._isSelf(receiver) || receiver === Opal.nil) {
             switch (name) {

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -46,6 +46,16 @@ const MicroBitConverter = {
                     this._setParent(rubyBlock, block);
                 }
                 break;
+            case 'microbit_pin_connected':
+                if (args.length === 2 && this._isNumber(args[1])) {
+                    block = this._createBlock('microbit_whenPinConnected', 'hat');
+                    this._addFieldInput(
+                        block, 'PIN', 'microbit_menu_touchPins', 'touchPins',
+                        args[1], '0'
+                    )
+                    this._setParent(rubyBlock, block);
+                }
+                break;
             }
         } else if (this._isSelf(receiver) || receiver === Opal.nil) {
             switch (name) {

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -79,6 +79,30 @@ const MicroBitConverter = {
                     );
                 }
                 break;
+            case 'display':
+                make_display_block:
+                if (args.length === 5) {
+                    for (const arg of args) {
+                        if (!this._isString(arg)) {
+                            break make_display_block;
+                        }
+                    } 
+
+                    block = this._changeBlock(receiver, 'microbit_displaySymbol', 'statement');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
+
+                    var matrix = '';
+                    for (const arg of args) {
+                        matrix += arg; 
+                    } 
+                    matrix = matrix.replace(/\./g, '0');
+                    this._addFieldInput(
+                        block, 'MATRIX', 'matrix', 'MATRIX',
+                        matrix, null 
+                    );
+                }
+                break;
             case 'display_text':
                 if (args.length === 1 && this._isString(args[0])) {
                     block = this._changeBlock(receiver, 'microbit_displayText', 'statement');

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -21,7 +21,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'BTN', 'microbit_menu_buttons', 'buttons',
                         args[1], 'A'
-                    )
+                    );
                     this._setParent(rubyBlock, block);
                 }
                 break;
@@ -41,7 +41,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'DIRECTION', 'microbit_menu_tiltDirectionAny', 'tiltDirectionAny',
                         args[1], 'any'
-                    )
+                    );
                     this._setParent(rubyBlock, block);
                 }
                 break;
@@ -51,7 +51,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'PIN', 'microbit_menu_touchPins', 'touchPins',
                         args[1], '0'
-                    )
+                    );
                     this._setParent(rubyBlock, block);
                 }
                 break;
@@ -79,14 +79,7 @@ const MicroBitConverter = {
                 }
                 break;
             case 'display':
-                make_display_block:
-                if (args.length === 5) {
-                    for (const arg of args) {
-                        if (!this._isString(arg)) {
-                            break make_display_block;
-                        }
-                    } 
-
+                if (args.length === 5 && args.every((i) => { return this._isString(i); })) {
                     block = this._changeBlock(receiver, 'microbit_displaySymbol', 'statement');
                     delete this._context.blocks[receiver.inputs.EXPRESSION.block];
                     delete receiver.inputs.EXPRESSION;
@@ -95,7 +88,7 @@ const MicroBitConverter = {
                     for (const arg of args) {
                         matrix += arg; 
                     } 
-                    matrix = matrix.replace(/\./g, '0');
+                    matrix = matrix.replace(/[1-9]/g, '1').replace(/[^1-9]/g, '0');
                     this._addFieldInput(
                         block, 'MATRIX', 'matrix', 'MATRIX',
                         matrix, null 
@@ -127,7 +120,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'DIRECTION', 'microbit_menu_tiltDirectionAny', 'tiltDirectionAny',
                         args[0], 'any'
-                    )
+                    );
                 }
                 break;
             case 'tilt_angle':
@@ -139,7 +132,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'DIRECTION', 'microbit_menu_tiltDirection', 'tiltDirection',
                         args[0], 'front'
-                    )
+                    );
                 }
                 break;
             }

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -59,6 +59,15 @@ const MicroBitConverter = {
                     );
                 }
                 break;
+            case 'display_text':
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._changeBlock(receiver, 'microbit_displayText', 'sentence');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
+
+                    this._addTextInput(block, 'TEXT', args[0], 'Hello!');
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -97,6 +97,18 @@ const MicroBitConverter = {
                     )
                 }
                 break;
+            case 'tilt_angle':
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._changeBlock(receiver, 'microbit_getTiltAngle', 'value');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
+
+                    this._addFieldInput(
+                        block, 'DIRECTION', 'microbit_menu_tiltDirection', 'tiltDirection',
+                        args[0], 'front'
+                    )
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -9,7 +9,6 @@ const MicroBitConverter = {
     // eslint-disable-next-line no-unused-vars
     onSend: function (receiver, name, args, rubyBlockArgs, rubyBlock) {
         let block;
-        console.log(arguments);
         if ((this._isSelf(receiver) || receiver === Opal.nil) &&
             name === 'when' &&
             args.length >= 1 && args[0].type === 'sym' &&

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -16,6 +16,16 @@ const MicroBitConverter = {
             rubyBlockArgs && rubyBlockArgs.length === 0 &&
             rubyBlock) {
             switch (args[0].value) {
+            case 'microbit_button_pressed':
+                if (args.length === 2 && this._isString(args[1])) {
+                    block = this._createBlock('microbit_whenButtonPressed', 'hat');
+                    this._addFieldInput(
+                        block, 'BTN', 'microbit_menu_buttons', 'buttons',
+                        args[1], 'A'
+                    )
+                    this._setParent(rubyBlock, block);
+                }
+                break;
             }
         } else if (this._isSelf(receiver) || receiver === Opal.nil) {
             switch (name) {

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -1,10 +1,48 @@
 /* global Opal */
 import _ from 'lodash';
 
+const MicroBit = 'microbit';
 /**
  * MicroBit converter
  */
 const MicroBitConverter = {
+    // eslint-disable-next-line no-unused-vars
+    onSend: function (receiver, name, args, rubyBlockArgs, rubyBlock) {
+        let block;
+        console.log(arguments);
+        if ((this._isSelf(receiver) || receiver === Opal.nil) &&
+            name === 'when' &&
+            args.length >= 1 && args[0].type === 'sym' &&
+            rubyBlockArgs && rubyBlockArgs.length === 0 &&
+            rubyBlock) {
+            switch (args[0].value) {
+            }
+        } else if (this._isSelf(receiver) || receiver === Opal.nil) {
+            switch (name) {
+            case 'microbit':
+                if (args.length === 0) {
+                    block = this._createRubyExpressionBlock(MicroBit);
+                }
+                break;
+            }
+        } else if (this._equalRubyExpression(receiver, MicroBit)) {
+            switch (name) {
+            case 'button_pressed?':
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._changeBlock(receiver, 'microbit_isButtonPressed', 'value_boolean');
+                    delete this._context.blocks[receiver.inputs.EXPRESSION.block];
+                    delete receiver.inputs.EXPRESSION;
+
+                    this._addFieldInput(
+                        block, 'BTN', 'microbit_menu_buttons', 'buttons',
+                        args[0], 'A'
+                    );
+                }
+                break;
+            }
+        }
+        return block;
+    }
 };
 
 export default MicroBitConverter;

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -31,7 +31,7 @@ const MicroBitConverter = {
                     this._addFieldInput(
                         block, 'GESTURE', 'microbit_menu_gestures', 'gestures',
                         args[1], 'moved'
-                    )
+                    );
                     this._setParent(rubyBlock, block);
                 }
                 break;


### PR DESCRIPTION
拡張機能「microbit」の10関数についてルビーからブロックに変換を行うコンバーターを追加しました。
microbit.display 関数のコンバーターについて、
・ラベルを用いたループからの脱出
・正規表現を用いた置き換え処理
をしていますが、これらは何か問題があったり、他に効率の良い処理があるかもしれません。もしそうであればご指摘をお願いします。