### PR TITLE
suppress warning on costume tab.

### DIFF
--- a/src/components/asset-panel/selector.jsx
+++ b/src/components/asset-panel/selector.jsx
@@ -102,6 +102,7 @@ Selector.propTypes = {
     draggingType: PropTypes.oneOf(Object.keys(DragConstants)),
     isRtl: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape({
+        dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
         url: PropTypes.string,
         name: PropTypes.string.isRequired
     })),

--- a/src/containers/sprite-selector-item.jsx
+++ b/src/containers/sprite-selector-item.jsx
@@ -151,7 +151,7 @@ SpriteSelectorItem.propTypes = {
     asset: PropTypes.instanceOf(storage.Asset),
     costumeURL: PropTypes.string,
     dispatchSetHoveredSprite: PropTypes.func.isRequired,
-    dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    dragPayload: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
     dragType: PropTypes.string,
     dragging: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
### Resolves

- Resolves #

Suppress below warning on Costume tab.

```
react_devtools_backend.js:6 Warning: Failed prop type: Invalid prop `dragPayload` supplied to `SpriteSelectorItem`.
    in SpriteSelectorItem (created by Connect(SpriteSelectorItem))
    in Connect(SpriteSelectorItem) (created by Selector)
    in div (created by SortableAsset)
    in SortableAsset (created by Selector)
    in div (created by Box)
    in Box (created by Selector)
    in div (created by Box)
    in Box (created by Selector)
    in Selector (created by SortableWrapper)
    in SortableWrapper (created by Connect(SortableWrapper))
    in Connect(SortableWrapper) (created by AssetPanel)
    in div (created by Box)
    in Box (created by AssetPanel)
    in AssetPanel (created by CostumeTab)
    in CostumeTab (created by Connect(CostumeTab))
    in Connect(CostumeTab) (created by InjectIntl(Connect(CostumeTab)))
    in InjectIntl(Connect(CostumeTab)) (created by ErrorBoundaryWrapper)
    in ErrorBoundary (created by Connect(ErrorBoundary))
    in Connect(ErrorBoundary) (created by ErrorBoundaryWrapper)
    in ErrorBoundaryWrapper (created by MediaQuery)
    in div (created by TabPanel)
    in TabPanel (created by MediaQuery)
    in div (created by UncontrolledTabs)
    in UncontrolledTabs (created by Tabs)
    in Tabs (created by MediaQuery)
```

### Browser Coverage

Mac
 * [x] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
