### PR TITLE
Change npm start to open url automatically

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,9 +20,10 @@ const base = {
     devtool: 'cheap-module-source-map',
     devServer: {
         contentBase: path.resolve(__dirname, 'build'),
-        host: '0.0.0.0',
+        host: process.env.SMALRUBY3_HOST,
         disableHostCheck: true,
-        port: process.env.PORT || 8601
+        port: process.env.PORT || 8601,
+        open: true
     },
     output: {
         library: 'GUI',


### PR DESCRIPTION
### Resolves

This change will be able to omit input url(https://localhost:8601) in your browser.

Windows
 * [OK] Chrome 
