### PR TITLE
wedo2の命令のいくつかをRubyからブロックに変換できるようにしました

### DIFF
--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -40,6 +40,21 @@ const Wedo2Converter = {
                     this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
                     break;
                 }
+            case 'wedo2_set_motor_direction':
+                if (args.length === 2 && this._isString(args[0]) && this._isString(args[1])){
+                    block = this._createBlock('wedo2_setMotorDirection', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addInput(
+                        block,
+                        'MOTOR_DIRECTION',
+                        this._createFieldBlock('wedo2_menu_MOTOR_DIRECTION', 'MOTOR_DIRECTION', args[1])
+                    );
+                }
+                break;
             case 'wedo2_set_light_color':
                 if (args.length === 1 && this._isNumberOrBlock(args[0])) {
                     block = this._createBlock('wedo2_setLightHue', 'statement');

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -14,6 +14,10 @@ const Wedo2Converter = {
                 block = this._createBlock('wedo2_motorOn', 'statement');
                 this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
                 break;
+            case 'wedo2_trun_motor_off':
+                block = this._createBlock('wedo2_motorOff', 'statement');
+                this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
+                break;
             case 'wedo2_set_light_color':
                 if (args.length === 1 && this._isNumberOrBlock(args[0])) {
                     block = this._createBlock('wedo2_setLightHue', 'statement');

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -10,6 +10,10 @@ const Wedo2Converter = {
         let block;
         if ((this._isSelf(receiver) || receiver === Opal.nil) && !rubyBlock) {
             switch (name) {
+            case 'wedo2_trun_motor_on':
+                block = this._createBlock('wedo2_motorOn', 'statement');
+                this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
+                break;
             case 'wedo2_set_light_color':
                 if (args.length === 1 && this._isNumberOrBlock(args[0])) {
                     block = this._createBlock('wedo2_setLightHue', 'statement');

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -29,6 +29,17 @@ const Wedo2Converter = {
                 block = this._createBlock('wedo2_motorOff', 'statement');
                 this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
                 break;
+            case 'wedo2_set_motor_power':
+                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])){
+                    block = this._createBlock('wedo2_startMotorPower', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
+                    break;
+                }
             case 'wedo2_set_light_color':
                 if (args.length === 1 && this._isNumberOrBlock(args[0])) {
                     block = this._createBlock('wedo2_setLightHue', 'statement');

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -10,6 +10,17 @@ const Wedo2Converter = {
         let block;
         if ((this._isSelf(receiver) || receiver === Opal.nil) && !rubyBlock) {
             switch (name) {
+            case 'wedo2_turn_motor_on_for':
+                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])){
+                    block = this._createBlock('wedo2_motorOnFor', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addNumberInput(block, 'DURATION', 'math_number', args[1], 1);
+                }
+                break;
             case 'wedo2_trun_motor_on':
                 block = this._createBlock('wedo2_motorOn', 'statement');
                 this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -25,8 +25,8 @@ const Wedo2Converter = {
                 if (args.length === 1 && this._isString(args[0])) {
                     block = this._createBlock('wedo2_motorOn', 'statement');
                     this._addInput(
-                        block, 
-                        'MOTOR_ID', 
+                        block,
+                        'MOTOR_ID',
                         this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
                     );
                 }
@@ -35,8 +35,8 @@ const Wedo2Converter = {
                 if (args.length === 1 && this._isString(args[0])) {
                     block = this._createBlock('wedo2_motorOff', 'statement');
                     this._addInput(
-                        block, 
-                        'MOTOR_ID', 
+                        block,
+                        'MOTOR_ID',
                         this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
                     );
                 }

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -11,7 +11,7 @@ const Wedo2Converter = {
         if ((this._isSelf(receiver) || receiver === Opal.nil) && !rubyBlock) {
             switch (name) {
             case 'wedo2_turn_motor_on_for':
-                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])){
+                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])) {
                     block = this._createBlock('wedo2_motorOnFor', 'statement');
                     this._addInput(
                         block,
@@ -22,15 +22,27 @@ const Wedo2Converter = {
                 }
                 break;
             case 'wedo2_trun_motor_on':
-                block = this._createBlock('wedo2_motorOn', 'statement');
-                this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._createBlock('wedo2_motorOn', 'statement');
+                    this._addInput(
+                        block, 
+                        'MOTOR_ID', 
+                        this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                }
                 break;
             case 'wedo2_trun_motor_off':
-                block = this._createBlock('wedo2_motorOff', 'statement');
-                this._addInput(block, 'MOTOR_ID', this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0]))
+                if (args.length === 1 && this._isString(args[0])) {
+                    block = this._createBlock('wedo2_motorOff', 'statement');
+                    this._addInput(
+                        block, 
+                        'MOTOR_ID', 
+                        this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                }
                 break;
             case 'wedo2_set_motor_power':
-                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])){
+                if (args.length === 2 && this._isString(args[0]) && this._isNumberOrBlock(args[1])) {
                     block = this._createBlock('wedo2_startMotorPower', 'statement');
                     this._addInput(
                         block,
@@ -38,8 +50,8 @@ const Wedo2Converter = {
                         this._createFieldBlock('wedo2_menu_MOTOR_ID', 'MOTOR_ID', args[0])
                     );
                     this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
-                    break;
                 }
+                break;
             case 'wedo2_set_motor_direction':
                 if (args.length === 2 && this._isString(args[0]) && this._isString(args[1])){
                     block = this._createBlock('wedo2_setMotorDirection', 'statement');


### PR DESCRIPTION
変換できるようにしたブロックは以下です。

- wedo2_turn_motor_on_for
- wedo2_trun_motor_on
- wedo2_trun_motor_off
- wedo2_set_motor_power
- wedo2_set_motor_directionRuby

- - -

以下のエラーに対応すること

```
/home/travis/build/smalruby/smalruby3-gui/src/lib/ruby-to-blocks-converter/wedo2.js
  28:31  error  Trailing spaces not allowed  no-trailing-spaces
  29:36  error  Trailing spaces not allowed  no-trailing-spaces
  38:31  error  Trailing spaces not allowed  no-trailing-spaces
  39:36  error  Trailing spaces not allowed  no-trailing-spaces
```

2020/08/20 11:24 修正完了しました