### PR TITLE
BoostのRubyからブロックへの変換を追加

### DIFF
--- a/src/lib/ruby-generator/boost.js
+++ b/src/lib/ruby-generator/boost.js
@@ -47,7 +47,7 @@ export default function (Generator) {
     Generator.boost_setMotorDirection = function (block) {
         const motorid = Generator.valueToCode(block, 'MOTOR_ID', Generator.ORDER_NONE) || null;
         const motordirection = Generator.valueToCode(block, 'MOTOR_DIRECTION') || null;
-        return `boost_motor_set_direction_for(${motorid}, ${motordirection})\n`
+        return `boost_motor_set_direction_for(${motorid}, ${motordirection})\n`;
     };
 
     Generator.boost_menu_MOTOR_REPORTER_ID = function (block) {
@@ -58,7 +58,7 @@ export default function (Generator) {
 
     Generator.boost_getMotorPosition = function (block) {
         const motorreporterid = Generator.valueToCode(block, 'MOTOR_REPORTER_ID', Generator.ORDER_NONE) || null;
-        return `boost_motor_get_position(${motorreporterid})\n`
+        return `boost_motor_get_position(${motorreporterid})\n`;
     };
 
     Generator.boost_menu_COLOR = function (block) {
@@ -70,12 +70,12 @@ export default function (Generator) {
     Generator.boost_whenColor = function (block) {
         block.isStatement = true;
         const color = Generator.valueToCode(block, 'COLOR', Generator.ORDER_NONE) || null;
-        return `${Generator.spriteName()}.when(:boost_color, ${color}) do\n`
+        return `${Generator.spriteName()}.when(:boost_color, ${color}) do\n`;
     };
 
     Generator.boost_seeingColor = function (block) {
         const color = Generator.valueToCode(block, 'COLOR', Generator.ORDER_NONE) || null;
-        return `boost_seeing_color?(${color})\n`
+        return `boost_seeing_color?(${color})\n`;
     };
 
     Generator.boost_menu_TILT_DIRECTION_ANY = function (block) {
@@ -87,7 +87,7 @@ export default function (Generator) {
     Generator.boost_whenTilted = function (block) {
         block.isStatement = true;
         const tiltdirectionany = Generator.valueToCode(block, 'TILT_DIRECTION_ANY', Generator.ORDER_NONE) || null;
-        return `${Generator.spriteName()}.when(:boost_tilted, ${tiltdirectionany}) do\n`
+        return `${Generator.spriteName()}.when(:boost_tilted, ${tiltdirectionany}) do\n`;
     };
 
     Generator.boost_menu_TILT_DIRECTION = function (block) {
@@ -98,12 +98,12 @@ export default function (Generator) {
 
     Generator.boost_getTiltAngle = function (block) {
         const tiltdirection = Generator.valueToCode(block, 'TILT_DIRECTION', Generator.ORDER_NONE) || null;
-        return `boost_get_tilt_angle(${tiltdirection})\n`
+        return `boost_get_tilt_angle(${tiltdirection})\n`;
     };
 
     Generator.boost_setLightHue = function (block) {
         const hue = Generator.valueToCode(block, 'HUE', Generator.ORDER_NONE) || null;
-        return `boost_set_light_color(${hue})\n`
+        return `boost_set_light_color(${hue})\n`;
     };
 
     return Generator;

--- a/src/lib/ruby-generator/boost.js
+++ b/src/lib/ruby-generator/boost.js
@@ -38,5 +38,73 @@ export default function (Generator) {
         return `boost_motor_set_power_for(${motorid}, ${power})\n`;
     };
 
+    Generator.boost_menu_MOTOR_DIRECTION = function (block) {
+        const index = Generator.getFieldValue(block, 'MOTOR_DIRECTION') || 0;
+        const motordirection = Generator.quote_(index);
+        return [motordirection, Generator.ORDER_ATOMIC];
+    };
+
+    Generator.boost_setMotorDirection = function (block) {
+        const motorid = Generator.valueToCode(block, 'MOTOR_ID', Generator.ORDER_NONE) || null;
+        const motordirection = Generator.valueToCode(block, 'MOTOR_DIRECTION') || null;
+        return `boost_motor_set_direction_for(${motorid}, ${motordirection})\n`
+    };
+
+    Generator.boost_menu_MOTOR_REPORTER_ID = function (block) {
+        const index = Generator.getFieldValue(block, 'MOTOR_REPORTER_ID') || 0;
+        const motorreporterid = Generator.quote_(index);
+        return [motorreporterid, Generator.ORDER_ATOMIC];
+    };
+
+    Generator.boost_getMotorPosition = function (block) {
+        const motorreporterid = Generator.valueToCode(block, 'MOTOR_REPORTER_ID', Generator.ORDER_NONE) || null;
+        return `boost_motor_get_position(${motorreporterid})\n`
+    };
+
+    Generator.boost_menu_COLOR = function (block) {
+        const index = Generator.getFieldValue(block, 'COLOR') || 0;
+        const color = Generator.quote_(index);
+        return [color, Generator.ORDER_ATOMIC];
+    };
+
+    Generator.boost_whenColor = function (block) {
+        block.isStatement = true;
+        const color = Generator.valueToCode(block, 'COLOR', Generator.ORDER_NONE) || null;
+        return `${Generator.spriteName()}.when(:boost_color, ${color}) do\n`
+    };
+
+    Generator.boost_seeingColor = function (block) {
+        const color = Generator.valueToCode(block, 'COLOR', Generator.ORDER_NONE) || null;
+        return `boost_seeing_color?(${color})\n`
+    };
+
+    Generator.boost_menu_TILT_DIRECTION_ANY = function (block) {
+        const index = Generator.getFieldValue(block, 'TILT_DIRECTION_ANY') || 0;
+        const tiltdirectionany = Generator.quote_(index);
+        return [tiltdirectionany, Generator.ORDER_ATOMIC];
+    };
+
+    Generator.boost_whenTilted = function (block) {
+        block.isStatement = true;
+        const tiltdirectionany = Generator.valueToCode(block, 'TILT_DIRECTION_ANY', Generator.ORDER_NONE) || null;
+        return `${Generator.spriteName()}.when(:boost_tilted, ${tiltdirectionany}) do\n`
+    };
+
+    Generator.boost_menu_TILT_DIRECTION = function (block) {
+        const index = Generator.getFieldValue(block, 'TILT_DIRECTION') || 0;
+        const tiltdirection = Generator.quote_(index);
+        return [tiltdirection, Generator.ORDER_ATOMIC];
+    };
+
+    Generator.boost_getTiltAngle = function (block) {
+        const tiltdirection = Generator.valueToCode(block, 'TILT_DIRECTION', Generator.ORDER_NONE) || null;
+        return `boost_get_tilt_angle(${tiltdirection})\n`
+    };
+
+    Generator.boost_setLightHue = function (block) {
+        const hue = Generator.valueToCode(block, 'HUE', Generator.ORDER_NONE) || null;
+        return `boost_set_light_color(${hue})\n`
+    };
+
     return Generator;
 }

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -74,6 +74,17 @@ const BoostConverter = {
                         this._createFieldBlock('boost_menu_MOTOR_DIRECTION', 'MOTOR_DIRECTION', args[1])
                     );
                 }
+                break;
+            case 'boost_motor_get_position':
+                if (args.length === 1 && this._isStringOrBlock(args[0])) {
+                    block = this._createBlock('boost_getMotorPosition', 'value');
+                    this._addInput(
+                        block,
+                        'MOTOR_REPORTER_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_REPORTER_ID', 'MOTOR_REPORTER_ID', args[0])
+                    );
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -59,6 +59,7 @@ const BoostConverter = {
                     );
                     this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
                 }
+                break;
             case 'boost_motor_set_direction_for':
                 if (args.length === 2 && this._isStringOrBlock(args[0]) && this._isStringOrBlock(args[1])) {
                     block = this._createBlock('boost_setMotorDirection', 'statement');

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -21,6 +21,17 @@ const BoostConverter = {
                     this._addNumberInput(block, 'DURATION', 'math_number', args[1], 1);
                 }
                 break;
+            case 'boost_motor_turn_this_way_for':
+                if (args.length === 2 && this._isStringOrBlock(args[0]) && this._isNumberOrBlock(args[1])) {
+                    block = this._createBlock('boost_motorOnForRotation', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addNumberInput(block, 'ROTATION', 'math_number', args[1], 1);
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -85,6 +85,16 @@ const BoostConverter = {
                     );
                 }
                 break;
+            case 'boost_seeing_color?':
+                if (args.length === 1 && this._isStringOrBlock(args[0])) {
+                    block = this._createBlock('boost_seeingColor', 'boolean');
+                    this._addInput(
+                        block,
+                        'COLOR',
+                        this._createFieldBlock('boost_menu_COLOR', 'COLOR', args[0])
+                    );
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -112,6 +112,23 @@ const BoostConverter = {
                 }
                 break;
             }
+        } else if ((this._isSelf(receiver) || receiver === Opal.nil) &&
+        name === 'when' &&
+        args.length === 2 && args[0].type === 'sym' &&
+        this._isStringOrBlock(args[1]) &&
+        rubyBlockArgs && rubyBlockArgs.length === 0 &&
+        rubyBlock) {
+            switch(args[0].value) {
+            case 'boost_color':
+                block = this._createBlock('boost_whenColor', 'hat');
+                this._addInput(
+                    block,
+                    'COLOR',
+                    this._createFieldBlock('boost_menu_COLOR', 'COLOR', args[1])
+                );
+                this._setParent(rubyBlock, block);
+                break;
+            }
         }
         return block;
     }

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -105,6 +105,12 @@ const BoostConverter = {
                     );
                 }
                 break;
+            case 'boost_set_light_color':
+                if (args.length === 1 && this._isNumberOrBlock(args[0])) {
+                    block = this._createBlock('boost_setLightHue', 'statement');
+                    this._addNumberInput(block, 'HUE', 'math_number', args[0], 100);
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -49,6 +49,16 @@ const BoostConverter = {
                     );
                 }
                 break;
+            case 'boost_motor_set_power_for':
+                if (args.length === 2 && this._isStringOrBlock(args[0]) && this._isNumberOrBlock(args[1])) {
+                    block = this._createBlock('boost_setMotorPower', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
+                }
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -59,6 +59,20 @@ const BoostConverter = {
                     );
                     this._addNumberInput(block, 'POWER', 'math_number', args[1], 100);
                 }
+            case 'boost_motor_set_direction_for':
+                if (args.length === 2 && this._isStringOrBlock(args[0]) && this._isStringOrBlock(args[1])) {
+                    block = this._createBlock('boost_setMotorDirection', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addInput(
+                        block,
+                        'MOTOR_DIRECTION',
+                        this._createFieldBlock('boost_menu_MOTOR_DIRECTION', 'MOTOR_DIRECTION', args[1])
+                    );
+                }
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -1,0 +1,30 @@
+/* global Opal */
+import _ from 'lodash';
+
+/**
+ * Boost converter
+ */
+const BoostConverter = {
+    // eslint-disable-next-line no-unused-vars
+    onSend: function (receiver, name, args, rubyBlockArgs, rubyBlock) {
+        let block;
+        if ((this._isSelf(receiver) || receiver === Opal.nil) && !rubyBlock) {
+            switch (name) {
+            case 'boost_motor_turn_on_for':
+                if (args.length === 2 && this._isStringOrBlock(args[0]) && this._isNumberOrBlock(args[1])) {
+                    block = this._createBlock('boost_motorOnFor', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                    this._addNumberInput(block, 'DURATION', 'math_number', args[1], 1);
+                }
+                break;
+            }
+        }
+        return block;
+    }
+};
+
+export default BoostConverter;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -39,6 +39,16 @@ const BoostConverter = {
                     this._addNumberInput(block, 'ROTATION', 'math_number', args[1], 1);
                 }
                 break;
+            case 'boost_motor_turn_off_for':
+                if (args.length === 1 && this._isStringOrBlock(args[0])) {
+                    block = this._createBlock('boost_motorOff', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -118,7 +118,7 @@ const BoostConverter = {
         this._isStringOrBlock(args[1]) &&
         rubyBlockArgs && rubyBlockArgs.length === 0 &&
         rubyBlock) {
-            switch(args[0].value) {
+            switch (args[0].value) {
             case 'boost_color':
                 block = this._createBlock('boost_whenColor', 'hat');
                 this._addInput(

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -95,6 +95,16 @@ const BoostConverter = {
                     );
                 }
                 break;
+            case 'boost_get_tilt_angle':
+                if (args.length === 1 && this._isStringOrBlock(args[0])) {
+                    block = this._createBlock('boost_getTiltAngle', 'value');
+                    this._addInput(
+                        block,
+                        'TILT_DIRECTION',
+                        this._createFieldBlock('boost_menu_TILT_DIRECTION', 'TILT_DIRECTION', args[0])
+                    );
+                }
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -19,6 +19,13 @@ const BoostConverter = {
                         this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
                     );
                     this._addNumberInput(block, 'DURATION', 'math_number', args[1], 1);
+                } else if (args.length === 1 && this._isStringOrBlock(args[0])) {
+                    block = this._createBlock('boost_motorOn', 'statement');
+                    this._addInput(
+                        block,
+                        'MOTOR_ID',
+                        this._createFieldBlock('boost_menu_MOTOR_ID', 'MOTOR_ID', args[0])
+                    );
                 }
                 break;
             case 'boost_motor_turn_this_way_for':

--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -128,6 +128,15 @@ const BoostConverter = {
                 );
                 this._setParent(rubyBlock, block);
                 break;
+            case 'boost_tilted':
+                block = this._createBlock('boost_whenTilted', 'hat');
+                this._addInput(
+                    block,
+                    'TILT_DIRECTION_ANY',
+                    this._createFieldBlock('boost_menu_TILT_DIRECTION_ANY', 'TILT_DIRECTION_ANY', args[1])
+                );
+                this._setParent(rubyBlock, block);
+                break;
             }
         }
         return block;

--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -26,6 +26,7 @@ import Wedo2Converter from './wedo2';
 import GdxForConverter from './gdx_for';
 import MeshConverter from './mesh';
 import SmalrubotS1Converter from './smalrubot_s1';
+import BoostConverter from './boost';
 
 const messages = defineMessages({
     couldNotConvertPremitive: {
@@ -85,6 +86,7 @@ class RubyToBlocksConverter {
             GdxForConverter,
             MeshConverter,
             SmalrubotS1Converter,
+            BoostConverter,
 
             MotionConverter,
             LooksConverter,


### PR DESCRIPTION
変換できるようにしたブロックは以下です。

- boost_motor_turn_on_for
- boost_motor_turn_this_way_for
- boost_motor_turn_on_for
- boost_motor_turn_off_for
- boost_motor_set_power_for
- boost_motor_set_direction_for
- boost_motor_get_position
- boost_seeing_color?
- boost_get_tilt_angle
- boost_set_light_color
- boost_color
- boost_tilted