### PR TITLE
Add EventsCompleter

### DIFF
--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -19,6 +19,7 @@ import 'brace/theme/clouds';
 import 'brace/ext/language_tools';
 
 import MotionCompleter from './ruby-tab/motion-completer';
+import EventsCompleter from './ruby-tab/events-completer';
 
 class RubyTab extends React.Component {
     constructor (props) {
@@ -90,7 +91,8 @@ class RubyTab extends React.Component {
         } = rubyCode;
 
         const completers = [
-            new MotionCompleter()
+            new MotionCompleter(),
+            new EventsCompleter()
         ];
 
         return (

--- a/src/containers/ruby-tab/events-completer.js
+++ b/src/containers/ruby-tab/events-completer.js
@@ -1,0 +1,48 @@
+/**
+ * Define Ruby code completer for Motion Blocks
+ */
+class EventsCompleter {
+    getCompletions (editor, session, pos, prefix, callback) {
+        const words = [
+            {
+                value: 'self.when(:flag_clicked) do\nend',
+                meta: '旗が押されたとき'
+            },
+            {
+                value: 'self.when(:key_pressed, "space") do\nend',
+                meta: 'スペースキーが押されたとき'
+            },
+            {
+                value: 'self.when(:clicked) do\nend',
+                meta: 'このスプライトがクリックされたとき'
+            },
+            {
+                value: 'self.when(:backdrop_switches, "背景1") do\nend',
+                meta: '背景が背景1になったとき'
+            },
+            {
+                value: 'self.when(:greater_than, "loudness", 10) do\nend',
+                meta: '音量が10より小さいとき'
+            },
+            {
+                value: 'self.when(:receive, "メッセージ1") do\nend',
+                meta: 'メッセージ1を受け取ったとき'
+            },
+            {
+                value: 'broadcast("メッセージ1")',
+                meta: 'メッセージ1を送る'
+            },
+            {
+                value: 'broadcast_and_wait("メッセージ1")',
+                meta: 'メッセージ1を送って待つ'
+            }
+        ];
+        const completions = [];
+        words.forEach(
+            w => completions.push(w)
+        );
+        callback(null, completions);
+    }
+}
+
+export default EventsCompleter;


### PR DESCRIPTION
MotionCompleter (#268) にならって、EventsCompleter を追加しました。

しかしまだ、いくつかの問題があります。
1. 改行を使うための`\n`が赤く表示される
![image](https://user-images.githubusercontent.com/50014309/101246551-72a48880-3757-11eb-8207-c5b7b266c58f.png)

2. 補完した後、ブロック(do ~ end)の間にカーソルをフォーカスさせたい
![image](https://user-images.githubusercontent.com/50014309/101246681-33c30280-3758-11eb-9471-d99e586b499d.png)
