### PR TITLE
docker-composeの追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,13 @@
 # dockerのイメージの作成
 #
 # ```
-# $ docker build
+# $ docker-compose build
+# ```
+#
+# docker-composeの起動
+#
+# ```
+# $ docker-compose up -d
 # ```
 #
 # dockerの起動
@@ -22,15 +28,16 @@
 # $ docker run -p 8601:8601 -d smalruby3-gui
 # ```
 
-FROM node:alpine
-MAINTAINER Kouji Takao
+FROM node:10
+LABEL maintaner "Kouji Takao, Seiya Aozasa"
 
-RUN apk add --no-cache git \
+RUN apt-get update -y \
+    && apt-get install git vim -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && cd /root \
     && git clone https://github.com/smalruby/smalruby3-gui \
     && cd smalruby3-gui \
     && npm install
 
 WORKDIR /root/smalruby3-gui
-EXPOSE 8601
-CMD ["npm","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+
+  smalruby3-gui:
+    build: .
+    ports:
+      - 0.0.0.0:8601:8601
+    command: npm start
+    volumes: 
+      - ./:/root/smalruby3-gui


### PR DESCRIPTION
docker-compose.ymlを追加し、それに伴いDockerfileも一部変更しました。
いくつか課題が残っており現在作業中です。
## 残課題
- composeでport forwardingしてもhttp://localhost:8601 にアクセスすることができない(smalruby3-guiのwebサーバが127.0.0.1でlistenされているのが原因？)
- volumeでマウントしたホストのフォルダのアクセス権限がないためnpm installができない