### PR TITLE
fix: resolve Scratch project loading hangs by copying storage chunks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,11 @@ const baseConfig = new ScratchWebpackConfigBuilder(
                 context: 'node_modules/scratch-vm/dist/web',
                 from: 'extension-worker.{js,js.map}',
                 noErrorOnMissing: true
+            },
+            {
+                context: 'node_modules/scratch-storage/dist/web',
+                from: 'chunks/*.{js,js.map}',
+                noErrorOnMissing: true
             }
         ]
     }));


### PR DESCRIPTION
## 概要
Scratchプロジェクトの読み込み時にハングする問題（Issue #375）を修正しました。

## 問題
- URLにScratchプロジェクトIDを指定した際、読込中の画面で止まってしまう
- 特定のアセット（スプライトのコスチューム）で `super.load()` が無限にハング
- プロジェクト読み込みが「loaded with token」で停止

## 根本原因
scratch-storageライブラリの動的インポート用webpackチャンクがビルド出力にコピーされていないため、必要なモジュールの読み込みに失敗していました。

## 修正内容
上流のscratch-gui [PR #9885](https://github.com/scratchfoundation/scratch-gui/pull/9885)の修正を適用：

```javascript
{
    context: 'node_modules/scratch-storage/dist/web',
    from: 'chunks/*.{js,js.map}',
    noErrorOnMissing: true
}
```

この修正により、scratch-storageの動的インポートチャンクが適切にビルド出力にコピーされます。

## 検証
- 修正前：http://smalruby.app/#1208975733 で読込中画面のまま停止
- 修正後：正常にプロジェクトが読み込まれ、エディタが表示される

## テストプラン
- [ ] 既存のローカルプロジェクト読み込み機能が正常に動作することを確認
- [ ] ScratchプロジェクトURL（例：#1208975733）で正常に読み込みできることを確認
- [ ] 様々なScratchプロジェクトIDで読み込みテストを実行
- [ ] ビルドエラーが発生しないことを確認

Closes #375

🤖 Generated with [Claude Code](https://claude.ai/code)