### PR TITLE
feat: add only_blocks URL parameter to filter displayed blocks

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -3,6 +3,7 @@ import debounce from 'lodash.debounce';
 import defaultsDeep from 'lodash.defaultsdeep';
 import makeToolboxXML from '../lib/make-toolbox-xml';
 import PropTypes from 'prop-types';
+import queryString from 'query-string';
 import React from 'react';
 import VMScratchBlocks from '../lib/blocks';
 import VM from 'scratch-vm';
@@ -359,11 +360,17 @@ class Blocks extends React.Component {
                 this.props.vm.runtime.getBlocksXML(target),
                 this.props.theme
             );
+            
+            // Parse only_blocks URL parameter
+            const queryParams = queryString.parse(location.search);
+            const onlyBlocks = queryParams.only_blocks;
+            
             return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,
                 targetSounds.length > 0 ? targetSounds[targetSounds.length - 1].name : '',
-                getColorsForTheme(this.props.theme)
+                getColorsForTheme(this.props.theme),
+                onlyBlocks
             );
         } catch {
             return null;

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -748,7 +748,9 @@ const xmlClose = '</xml>';
  */
 const parseOnlyBlocks = function (onlyBlocks) {
     if (!onlyBlocks) return [];
-    return onlyBlocks.split(',').map(pattern => pattern.trim()).filter(pattern => pattern.length > 0);
+    return onlyBlocks.split(',')
+        .map(pattern => pattern.trim())
+        .filter(pattern => pattern.length > 0);
 };
 
 /**
@@ -760,16 +762,15 @@ const parseOnlyBlocks = function (onlyBlocks) {
 const shouldIncludeBlock = function (blockType, allowedPatterns) {
     if (!allowedPatterns || allowedPatterns.length === 0) return true;
     
-    return allowedPatterns.some(pattern => {
-        // Exact match or prefix match
-        return blockType === pattern || blockType.startsWith(pattern);
-    });
+    return allowedPatterns.some(pattern =>
+        blockType === pattern || blockType.startsWith(pattern)
+    );
 };
 
 /**
  * Filters block XML content based on only_blocks patterns
  * @param {string} categoryXML - The category XML containing blocks
- * @param {Array.<string>} allowedPatterns - Array of allowed patterns  
+ * @param {Array.<string>} allowedPatterns - Array of allowed patterns
  * @param {string} categoryId - The category ID for logging
  * @returns {string} - Filtered category XML
  */
@@ -870,7 +871,7 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     const everything = [xmlOpen];
     
     // Helper function to add category if it has content
-    const addCategoryIfNotEmpty = (categoryXML) => {
+    const addCategoryIfNotEmpty = categoryXML => {
         if (categoryXML && categoryXML.trim() !== '') {
             everything.push(categoryXML, gap);
         }

--- a/src/reducers/toolbox.js
+++ b/src/reducers/toolbox.js
@@ -1,8 +1,19 @@
 const UPDATE_TOOLBOX = 'scratch-gui/toolbox/UPDATE_TOOLBOX';
 import makeToolboxXML from '../lib/make-toolbox-xml';
+import queryString from 'query-string';
+
+const getInitialToolboxXML = () => {
+    try {
+        const queryParams = queryString.parse(location.search);
+        const onlyBlocks = queryParams.only_blocks;
+        return makeToolboxXML(true, true, null, [], '', '', '', null, onlyBlocks);
+    } catch {
+        return makeToolboxXML(true);
+    }
+};
 
 const initialState = {
-    toolboxXML: makeToolboxXML(true)
+    toolboxXML: getInitialToolboxXML()
 };
 
 const reducer = function (state, action) {

--- a/test/integration/only-blocks-filter.test.js
+++ b/test/integration/only-blocks-filter.test.js
@@ -31,18 +31,18 @@ describe('only_blocks URL parameter filtering', () => {
         await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
         await clickText('Code');
         
-        // Check that all categories are visible
+        // Check that all categories are visible with specific block text from existing tests
         await clickBlocksCategory('Motion');
-        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        await findByText('10', scope.blocksTab); // move 10 steps block
         
         await clickBlocksCategory('Looks');
-        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
+        await findByText('Hello!', scope.blocksTab); // say Hello! block
         
         await clickBlocksCategory('Sound');
-        expect(await textExists('play sound', scope.blocksTab)).toBeTruthy();
+        await findByText('Meow', scope.blocksTab); // play sound Meow block
         
         await clickBlocksCategory('Events');
-        expect(await textExists('when', scope.blocksTab)).toBeTruthy();
+        await findByText('when', scope.blocksTab); // when flag clicked block
         
         const logs = await getLogs();
         expect(logs).toEqual([]);
@@ -56,14 +56,14 @@ describe('only_blocks URL parameter filtering', () => {
         
         // Motion category should be visible and contain blocks
         await clickBlocksCategory('Motion');
-        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
-        expect(await textExists('turn', scope.blocksTab)).toBeTruthy();
+        await findByText('10', scope.blocksTab); // move 10 steps block
+        await findByText('15', scope.blocksTab); // turn 15 degrees block
         
         // Other categories should be empty or not visible
         const looksExists = await textExists('Looks', scope.blocksTab);
         if (looksExists) {
             await clickBlocksCategory('Looks');
-            expect(await textExists('say', scope.blocksTab)).toBeFalsy();
+            expect(await textExists('Hello!', scope.blocksTab)).toBeFalsy();
         }
         
         // Variables and My Blocks should always be present
@@ -82,17 +82,17 @@ describe('only_blocks URL parameter filtering', () => {
         
         // Motion category should contain blocks
         await clickBlocksCategory('Motion');
-        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        await findByText('10', scope.blocksTab); // move 10 steps block
         
         // Looks category should contain blocks
         await clickBlocksCategory('Looks');
-        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
+        await findByText('Hello!', scope.blocksTab); // say Hello! block
         
         // Sound category should be empty or not visible
         const soundExists = await textExists('Sound', scope.blocksTab);
         if (soundExists) {
             await clickBlocksCategory('Sound');
-            expect(await textExists('play sound', scope.blocksTab)).toBeFalsy();
+            expect(await textExists('Meow', scope.blocksTab)).toBeFalsy();
         }
         
         // Variables and My Blocks should always be present
@@ -111,9 +111,9 @@ describe('only_blocks URL parameter filtering', () => {
         
         // Motion category should contain only the move steps block
         await clickBlocksCategory('Motion');
-        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
-        // Other motion blocks should not be present
-        expect(await textExists('turn', scope.blocksTab)).toBeFalsy();
+        await findByText('10', scope.blocksTab); // move 10 steps block should be present
+        // Other motion blocks should not be present (turn blocks use "15" as default)
+        expect(await textExists('15', scope.blocksTab)).toBeFalsy();
         
         // Variables and My Blocks should always be present
         expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
@@ -131,14 +131,13 @@ describe('only_blocks URL parameter filtering', () => {
         
         // Motion category should contain only move steps block
         await clickBlocksCategory('Motion');
-        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
-        expect(await textExists('turn', scope.blocksTab)).toBeFalsy();
+        await findByText('10', scope.blocksTab); // move 10 steps block should be present
+        expect(await textExists('15', scope.blocksTab)).toBeFalsy(); // turn blocks should not be present
         
         // Looks category should contain only say for secs block
         await clickBlocksCategory('Looks');
-        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
-        // Check that it's specifically the "say for secs" block, not just "say"
-        expect(await textExists('Hello!', scope.blocksTab)).toBeTruthy();
+        await findByText('Hello!', scope.blocksTab); // say Hello! for 2 secs block
+        await findByText('2', scope.blocksTab); // 2 seconds parameter
         
         // Variables and My Blocks should always be present
         expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
@@ -158,7 +157,7 @@ describe('only_blocks URL parameter filtering', () => {
         const motionExists = await textExists('Motion', scope.blocksTab);
         if (motionExists) {
             await clickBlocksCategory('Motion');
-            expect(await textExists('move', scope.blocksTab)).toBeFalsy();
+            expect(await textExists('10', scope.blocksTab)).toBeFalsy();
         }
         
         // Variables and My Blocks should always be present
@@ -177,7 +176,7 @@ describe('only_blocks URL parameter filtering', () => {
         
         // Variables should be present and functional
         await clickBlocksCategory('Variables');
-        expect(await textExists('my\u00A0variable', scope.blocksTab)).toBeTruthy();
+        await findByText('my\u00A0variable', scope.blocksTab);
         
         const logs = await getLogs();
         expect(logs).toEqual([]);
@@ -191,7 +190,7 @@ describe('only_blocks URL parameter filtering', () => {
         
         // My Blocks should be present and functional
         await clickBlocksCategory('My Blocks');
-        expect(await textExists('Make a Block', scope.blocksTab)).toBeTruthy();
+        await findByText('Make a Block', scope.blocksTab);
         
         const logs = await getLogs();
         expect(logs).toEqual([]);

--- a/test/integration/only-blocks-filter.test.js
+++ b/test/integration/only-blocks-filter.test.js
@@ -1,0 +1,199 @@
+import path from 'path';
+import SeleniumHelper from '../helpers/selenium-helper';
+
+const {
+    clickText,
+    clickBlocksCategory,
+    findByText,
+    getDriver,
+    getLogs,
+    loadUri,
+    notExistsByXpath,
+    scope,
+    textExists
+} = new SeleniumHelper();
+
+const uri = path.resolve(__dirname, '../../build/index.html');
+
+let driver;
+
+describe('only_blocks URL parameter filtering', () => {
+    beforeAll(() => {
+        driver = getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test('Shows all blocks when only_blocks parameter is not specified', async () => {
+        await loadUri(uri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Check that all categories are visible
+        await clickBlocksCategory('Motion');
+        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        
+        await clickBlocksCategory('Looks');
+        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
+        
+        await clickBlocksCategory('Sound');
+        expect(await textExists('play sound', scope.blocksTab)).toBeTruthy();
+        
+        await clickBlocksCategory('Events');
+        expect(await textExists('when', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Shows only motion blocks when only_blocks=motion_', async () => {
+        const testUri = `${uri}?only_blocks=motion_`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Motion category should be visible and contain blocks
+        await clickBlocksCategory('Motion');
+        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('turn', scope.blocksTab)).toBeTruthy();
+        
+        // Other categories should be empty or not visible
+        const looksExists = await textExists('Looks', scope.blocksTab);
+        if (looksExists) {
+            await clickBlocksCategory('Looks');
+            expect(await textExists('say', scope.blocksTab)).toBeFalsy();
+        }
+        
+        // Variables and My Blocks should always be present
+        expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('My Blocks', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Shows motion and looks blocks when only_blocks=motion_,looks_', async () => {
+        const testUri = `${uri}?only_blocks=motion_,looks_`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Motion category should contain blocks
+        await clickBlocksCategory('Motion');
+        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        
+        // Looks category should contain blocks
+        await clickBlocksCategory('Looks');
+        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
+        
+        // Sound category should be empty or not visible
+        const soundExists = await textExists('Sound', scope.blocksTab);
+        if (soundExists) {
+            await clickBlocksCategory('Sound');
+            expect(await textExists('play sound', scope.blocksTab)).toBeFalsy();
+        }
+        
+        // Variables and My Blocks should always be present
+        expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('My Blocks', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Shows only specific block when using exact match', async () => {
+        const testUri = `${uri}?only_blocks=motion_movesteps`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Motion category should contain only the move steps block
+        await clickBlocksCategory('Motion');
+        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        // Other motion blocks should not be present
+        expect(await textExists('turn', scope.blocksTab)).toBeFalsy();
+        
+        // Variables and My Blocks should always be present
+        expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('My Blocks', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Shows multiple specific blocks when using exact matches', async () => {
+        const testUri = `${uri}?only_blocks=motion_movesteps,looks_sayforsecs`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Motion category should contain only move steps block
+        await clickBlocksCategory('Motion');
+        expect(await textExists('move', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('turn', scope.blocksTab)).toBeFalsy();
+        
+        // Looks category should contain only say for secs block
+        await clickBlocksCategory('Looks');
+        expect(await textExists('say', scope.blocksTab)).toBeTruthy();
+        // Check that it's specifically the "say for secs" block, not just "say"
+        expect(await textExists('Hello!', scope.blocksTab)).toBeTruthy();
+        
+        // Variables and My Blocks should always be present
+        expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('My Blocks', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Shows only exception categories when no blocks match', async () => {
+        const testUri = `${uri}?only_blocks=nonexistent_block`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Core categories should be empty or not visible
+        const motionExists = await textExists('Motion', scope.blocksTab);
+        if (motionExists) {
+            await clickBlocksCategory('Motion');
+            expect(await textExists('move', scope.blocksTab)).toBeFalsy();
+        }
+        
+        // Variables and My Blocks should always be present
+        expect(await textExists('Variables', scope.blocksTab)).toBeTruthy();
+        expect(await textExists('My Blocks', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('Variables category is always visible regardless of filter', async () => {
+        const testUri = `${uri}?only_blocks=motion_`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // Variables should be present and functional
+        await clickBlocksCategory('Variables');
+        expect(await textExists('my\u00A0variable', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+
+    test('My Blocks category is always visible regardless of filter', async () => {
+        const testUri = `${uri}?only_blocks=motion_`;
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+        await clickText('Code');
+        
+        // My Blocks should be present and functional
+        await clickBlocksCategory('My Blocks');
+        expect(await textExists('Make a Block', scope.blocksTab)).toBeTruthy();
+        
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

- Implements `only_blocks` URL parameter to filter displayed blocks for tutorial scenarios
- Supports exact match (e.g., `motion_movesteps`) and prefix match (e.g., `motion_`) filtering
- Supports comma-separated multiple patterns (e.g., `motion_,looks_`)
- Always displays variables, myBlocks, and extension categories regardless of filter
- Automatically hides empty categories when all blocks are filtered out
- Includes comprehensive integration tests for all filtering scenarios

## Test plan

- [x] Manual testing with various URL parameter combinations
- [x] Integration tests covering all filtering scenarios
- [x] Verification that exception categories (variables, myBlocks, extensions) always appear
- [x] Error handling for invalid/non-matching patterns
- [x] Run full test suite to ensure no regressions

## Usage Examples

```
# Show only motion blocks
http://localhost:8601?only_blocks=motion_

# Show motion and looks blocks  
http://localhost:8601?only_blocks=motion_,looks_

# Show specific blocks only
http://localhost:8601?only_blocks=motion_movesteps,looks_sayforsecs
```

closes #369

🤖 Generated with [Claude Code](https://claude.ai/code)