### PR TITLE
feat: add URL pane to block display modal with filtering fixes

### DIFF
--- a/src/components/block-display-modal/block-display-modal.css
+++ b/src/components/block-display-modal/block-display-modal.css
@@ -487,6 +487,50 @@
     box-shadow: 0 0 0 2px rgba(76, 151, 255, 0.2);
 }
 
+.urlInputContainer {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    position: relative;
+}
+
+.copyButton {
+    width: 2rem;
+    height: 2rem;
+    margin-left: 0.5rem;
+    padding: 0.25rem;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.copyButton:hover {
+    background: #f5f5f5;
+    border-color: #4c97ff;
+}
+
+.copyButton:active {
+    transform: scale(0.95);
+}
+
+.copyButton.copied {
+    background: #4caf50;
+    border-color: #4caf50;
+    color: white;
+}
+
+.copyIcon {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+}
+
 /* RTL support */
 [dir="rtl"] .controls {
     flex-direction: row-reverse;

--- a/src/components/block-display-modal/block-display-modal.css
+++ b/src/components/block-display-modal/block-display-modal.css
@@ -3,7 +3,7 @@
 
 .modal-content {
     width: 500px;
-    height: 560px;
+    height: 625px;
     line-height: 1.75;
 }
 
@@ -15,7 +15,14 @@
     background: $ui-white;
     padding: 0;
     display: flex;
+    flex-direction: column;
     height: 100%;
+}
+
+.topSection {
+    display: flex;
+    flex: 1;
+    min-height: 0;
 }
 
 .leftPane {
@@ -442,6 +449,43 @@
     margin-left: 0.25rem;
 }
 
+
+/* URL pane styles */
+.urlPane {
+    width: 100%;
+    height: 65px;
+    padding: 1rem;
+    background: #F9F9F9;
+    border-top: 1px solid hsla(0, 0%, 0%, 0.1);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.urlLabel {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: hsla(0, 0%, 0%, 0.8);
+    flex-shrink: 0;
+}
+
+.urlInput {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    font-family: monospace;
+    background: white;
+    color: hsla(0, 0%, 0%, 0.9);
+}
+
+.urlInput:focus {
+    outline: none;
+    border-color: #4c97ff;
+    box-shadow: 0 0 0 2px rgba(76, 151, 255, 0.2);
+}
 
 /* RTL support */
 [dir="rtl"] .controls {

--- a/src/components/block-display-modal/block-display-modal.jsx
+++ b/src/components/block-display-modal/block-display-modal.jsx
@@ -8,7 +8,7 @@ import VMScratchBlocks from '../../lib/blocks';
 import Box from '../box/box.jsx';
 import Modal from '../../containers/modal.jsx';
 import blockDisplayIcon from '../menu-bar/block-display-icon.svg';
-import copyIcon from '../sound-editor/icon--copy.svg';
+import copyIcon from './icon--clipboard-copy.svg';
 
 import styles from './block-display-modal.css';
 

--- a/src/components/block-display-modal/block-display-modal.jsx
+++ b/src/components/block-display-modal/block-display-modal.jsx
@@ -261,6 +261,41 @@ class BlockDisplayModal extends React.Component {
         this.blockListRef = ref;
     }
 
+    generateOnlyBlocksUrl () {
+        const {selectedBlocks} = this.props;
+        const currentUrl = typeof window === 'undefined' ? '' : window.location.href;
+        
+        // Parse current URL to preserve hash
+        let baseUrl;
+        let hash;
+        try {
+            const url = new URL(currentUrl);
+            baseUrl = `${url.protocol}//${url.host}${url.pathname}`;
+            hash = url.hash;
+        } catch (e) {
+            return currentUrl;
+        }
+
+        // Generate only_blocks parameter from selected blocks
+        const onlyBlocksList = [];
+        Object.keys(selectedBlocks).forEach(categoryId => {
+            const blocksInCategory = selectedBlocks[categoryId] || [];
+            blocksInCategory.forEach(blockId => {
+                onlyBlocksList.push(blockId);
+            });
+        });
+
+        if (onlyBlocksList.length === 0) {
+            return currentUrl;
+        }
+
+        // Create new URL with only_blocks parameter using period separator
+        const onlyBlocksParam = onlyBlocksList.join('.');
+        const newUrl = `${baseUrl}?only_blocks=${encodeURIComponent(onlyBlocksParam)}${hash}`;
+        
+        return newUrl;
+    }
+
 
     getCategoryCheckboxState (categoryId) {
         const {selectedBlocks} = this.props;
@@ -438,7 +473,7 @@ class BlockDisplayModal extends React.Component {
                         <input
                             className={styles.urlInput}
                             type="text"
-                            value={typeof window === 'undefined' ? '' : window.location.href}
+                            value={this.generateOnlyBlocksUrl()}
                             readOnly
                         />
                     </Box>

--- a/src/components/block-display-modal/block-display-modal.jsx
+++ b/src/components/block-display-modal/block-display-modal.jsx
@@ -295,139 +295,152 @@ class BlockDisplayModal extends React.Component {
                 onRequestClose={onRequestClose}
             >
                 <Box className={styles.body}>
-                    <Box className={styles.leftPane}>
-                        <Box className={styles.categorySection}>
-                            <div className={styles.sectionTitle}>
-                                <FormattedMessage
-                                    defaultMessage="Categories:"
-                                    description="Title for block categories section"
-                                    id="gui.smalruby3.blockDisplayModal.categoriesTitle"
-                                />
-                            </div>
-                            {BLOCK_CATEGORIES.map((category, index) => {
-                                const checkboxState = this.getCategoryCheckboxState(category.id);
-                                return (
-                                    <div
-                                        key={category.id}
-                                        className={classNames(styles.categoryItem, {
-                                            [styles.selectedCategory]: selectedCategoryIndex === index
-                                        })}
-                                        data-category={category.id}
-                                    >
-                                        <input
-                                            type="checkbox"
-                                            className={styles.checkbox}
+                    <Box className={styles.topSection}>
+                        <Box className={styles.leftPane}>
+                            <Box className={styles.categorySection}>
+                                <div className={styles.sectionTitle}>
+                                    <FormattedMessage
+                                        defaultMessage="Categories:"
+                                        description="Title for block categories section"
+                                        id="gui.smalruby3.blockDisplayModal.categoriesTitle"
+                                    />
+                                </div>
+                                {BLOCK_CATEGORIES.map((category, index) => {
+                                    const checkboxState = this.getCategoryCheckboxState(category.id);
+                                    return (
+                                        <div
+                                            key={category.id}
+                                            className={classNames(styles.categoryItem, {
+                                                [styles.selectedCategory]: selectedCategoryIndex === index
+                                            })}
                                             data-category={category.id}
-                                            checked={checkboxState.checked}
-                                            ref={checkbox => {
-                                                if (checkbox) {
-                                                    checkbox.indeterminate = checkboxState.indeterminate;
-                                                }
-                                            }}
-                                            onChange={this.handleCategoryChange}
-                                        />
-                                        <span
-                                            className={styles.categoryName}
-                                            data-category-index={index}
-                                            onClick={this.handleCategorySelect}
                                         >
-                                            {this.ScratchBlocks && this.ScratchBlocks.Msg &&
-                                                this.ScratchBlocks.Msg[category.messageKey] ?
-                                                this.ScratchBlocks.Msg[category.messageKey] :
-                                                category.messageKey}
-                                        </span>
-                                    </div>
-                                );
-                            })}
-                        </Box>
-
-                        <Box className={styles.alwaysVisibleSection}>
-                            <div className={styles.sectionTitle}>
-                                <FormattedMessage
-                                    defaultMessage="Always Visible:"
-                                    description="Title for always visible categories section"
-                                    id="gui.smalruby3.blockDisplayModal.alwaysVisibleTitle"
-                                />
-                            </div>
-                            {ALWAYS_VISIBLE_CATEGORIES.map(category => (
-                                <div
-                                    key={category.id}
-                                    className={styles.categoryItem}
-                                >
-                                    <label className={styles.categoryLabel}>
-                                        <input
-                                            type="checkbox"
-                                            className={styles.checkbox}
-                                            checked
-                                            disabled
-                                        />
-                                        <span className={classNames(styles.categoryName, styles.alwaysVisibleText)}>
-                                            {category.messageKey ?
-                                                (this.ScratchBlocks && this.ScratchBlocks.Msg &&
+                                            <input
+                                                type="checkbox"
+                                                className={styles.checkbox}
+                                                data-category={category.id}
+                                                checked={checkboxState.checked}
+                                                ref={checkbox => {
+                                                    if (checkbox) {
+                                                        checkbox.indeterminate = checkboxState.indeterminate;
+                                                    }
+                                                }}
+                                                onChange={this.handleCategoryChange}
+                                            />
+                                            <span
+                                                className={styles.categoryName}
+                                                data-category-index={index}
+                                                onClick={this.handleCategorySelect}
+                                            >
+                                                {this.ScratchBlocks && this.ScratchBlocks.Msg &&
                                                     this.ScratchBlocks.Msg[category.messageKey] ?
                                                     this.ScratchBlocks.Msg[category.messageKey] :
-                                                    category.messageKey) :
-                                                intl.formatMessage({id: category.messageId})}
-                                        </span>
-                                    </label>
-                                </div>
-                            ))}
-                        </Box>
-                    </Box>
+                                                    category.messageKey}
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </Box>
 
-                    <Box className={styles.rightPane}>
-                        <Box
-                            className={styles.blockList}
-                            componentRef={this.setBlockListRef}
-                            onScroll={this.handleBlockListScroll}
-                        >
-                            {BLOCK_CATEGORIES.map((category, categoryIndex) => {
-                                const categoryBlocks = CATEGORY_BLOCKS[category.id] || [];
-                                return (
+                            <Box className={styles.alwaysVisibleSection}>
+                                <div className={styles.sectionTitle}>
+                                    <FormattedMessage
+                                        defaultMessage="Always Visible:"
+                                        description="Title for always visible categories section"
+                                        id="gui.smalruby3.blockDisplayModal.alwaysVisibleTitle"
+                                    />
+                                </div>
+                                {ALWAYS_VISIBLE_CATEGORIES.map(category => (
                                     <div
                                         key={category.id}
-                                        className={styles.categorySection}
-                                        data-category-index={categoryIndex}
+                                        className={styles.categoryItem}
                                     >
-                                        <div className={styles.categoryHeader}>
-                                            {this.ScratchBlocks && this.ScratchBlocks.Msg &&
-                                                this.ScratchBlocks.Msg[category.messageKey] ?
-                                                this.ScratchBlocks.Msg[category.messageKey] :
-                                                category.messageKey}
-                                        </div>
-                                        {categoryBlocks.map(blockType => {
-                                            const messageId = `gui.smalruby3.blockDisplayModal.${blockType}`;
-                                            const selectedBlocksInCategory = selectedBlocks[category.id] || [];
-                                            const isBlockSelected = selectedBlocksInCategory.includes(blockType);
-
-                                            return (
-                                                <div
-                                                    key={blockType}
-                                                    className={styles.blockItem}
-                                                >
-                                                    <label className={styles.blockLabel}>
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={isBlockSelected}
-                                                            className={styles.blockCheckbox}
-                                                            data-block={blockType}
-                                                            data-category={category.id}
-                                                            onChange={this.handleBlockChange}
-                                                        />
-                                                        <span className={styles.blockName}>
-                                                            {intl.formatMessage({
-                                                                id: messageId,
-                                                                defaultMessage: blockType
-                                                            })}
-                                                        </span>
-                                                    </label>
-                                                </div>
-                                            );
-                                        })}
+                                        <label className={styles.categoryLabel}>
+                                            <input
+                                                type="checkbox"
+                                                className={styles.checkbox}
+                                                checked
+                                                disabled
+                                            />
+                                            <span className={classNames(styles.categoryName, styles.alwaysVisibleText)}>
+                                                {category.messageKey ?
+                                                    (this.ScratchBlocks && this.ScratchBlocks.Msg &&
+                                                        this.ScratchBlocks.Msg[category.messageKey] ?
+                                                        this.ScratchBlocks.Msg[category.messageKey] :
+                                                        category.messageKey) :
+                                                    intl.formatMessage({id: category.messageId})}
+                                            </span>
+                                        </label>
                                     </div>
-                                );
-                            })}
+                                ))}
+                            </Box>
                         </Box>
+
+                        <Box className={styles.rightPane}>
+                            <Box
+                                className={styles.blockList}
+                                componentRef={this.setBlockListRef}
+                                onScroll={this.handleBlockListScroll}
+                            >
+                                {BLOCK_CATEGORIES.map((category, categoryIndex) => {
+                                    const categoryBlocks = CATEGORY_BLOCKS[category.id] || [];
+                                    return (
+                                        <div
+                                            key={category.id}
+                                            className={styles.categorySection}
+                                            data-category-index={categoryIndex}
+                                        >
+                                            <div className={styles.categoryHeader}>
+                                                {this.ScratchBlocks && this.ScratchBlocks.Msg &&
+                                                    this.ScratchBlocks.Msg[category.messageKey] ?
+                                                    this.ScratchBlocks.Msg[category.messageKey] :
+                                                    category.messageKey}
+                                            </div>
+                                            {categoryBlocks.map(blockType => {
+                                                const messageId = `gui.smalruby3.blockDisplayModal.${blockType}`;
+                                                const selectedBlocksInCategory = selectedBlocks[category.id] || [];
+                                                const isBlockSelected = selectedBlocksInCategory.includes(blockType);
+
+                                                return (
+                                                    <div
+                                                        key={blockType}
+                                                        className={styles.blockItem}
+                                                    >
+                                                        <label className={styles.blockLabel}>
+                                                            <input
+                                                                type="checkbox"
+                                                                checked={isBlockSelected}
+                                                                className={styles.blockCheckbox}
+                                                                data-block={blockType}
+                                                                data-category={category.id}
+                                                                onChange={this.handleBlockChange}
+                                                            />
+                                                            <span className={styles.blockName}>
+                                                                {intl.formatMessage({
+                                                                    id: messageId,
+                                                                    defaultMessage: blockType
+                                                                })}
+                                                            </span>
+                                                        </label>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    );
+                                })}
+                            </Box>
+                        </Box>
+                    </Box>
+                    <Box className={styles.urlPane}>
+                        <div className={styles.urlLabel}>
+                            {'URL:'}
+                        </div>
+                        <input
+                            className={styles.urlInput}
+                            type="text"
+                            value={typeof window === 'undefined' ? '' : window.location.href}
+                            readOnly
+                        />
                     </Box>
                 </Box>
             </Modal>

--- a/src/components/block-display-modal/block-display-modal.jsx
+++ b/src/components/block-display-modal/block-display-modal.jsx
@@ -155,6 +155,55 @@ export const CATEGORY_BLOCKS = {
     ]
 };
 
+/**
+ * Initialize block selection from only_blocks parameter
+ * @param {string} onlyBlocks - The only_blocks parameter value
+ * @returns {object} - Selected blocks object with categories initialized based on only_blocks
+ */
+export const initializeBlockSelectionFromOnlyBlocks = onlyBlocks => {
+    const selectedBlocks = {};
+    
+    // Always initialize each category
+    Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
+        selectedBlocks[categoryId] = [];
+    });
+    
+    // If no onlyBlocks parameter provided (null/undefined), select all blocks (default behavior)
+    if (onlyBlocks === null || typeof onlyBlocks === 'undefined') {
+        Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
+            selectedBlocks[categoryId] = [...CATEGORY_BLOCKS[categoryId]];
+        });
+        return selectedBlocks;
+    }
+    
+    // If empty string provided, return empty selections
+    if (!onlyBlocks) return selectedBlocks;
+    
+    // Parse only_blocks parameter
+    const patterns = onlyBlocks.split(/[,.]/)
+        .map(pattern => pattern.trim())
+        .filter(pattern => pattern.length > 0);
+    
+    // Process patterns to determine which blocks should be initially selected
+    patterns.forEach(pattern => {
+        Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
+            const categoryBlocks = CATEGORY_BLOCKS[categoryId] || [];
+            
+            // Check if pattern matches category prefix (e.g., "motion_" matches motion category)
+            if (pattern.endsWith('_') && pattern === `${categoryId}_`) {
+                // Select all blocks in this category
+                selectedBlocks[categoryId] = [...categoryBlocks];
+            } else if (categoryBlocks.includes(pattern)) {
+                // Select specific block if it exists in this category
+                if (!selectedBlocks[categoryId].includes(pattern)) {
+                    selectedBlocks[categoryId].push(pattern);
+                }
+            }
+        });
+    });
+    
+    return selectedBlocks;
+};
 
 class BlockDisplayModal extends React.Component {
     constructor (props) {

--- a/src/components/block-display-modal/block-display-modal.jsx
+++ b/src/components/block-display-modal/block-display-modal.jsx
@@ -65,11 +65,10 @@ export const CATEGORY_BLOCKS = {
         'looks_say',
         'looks_thinkforsecs',
         'looks_think',
-        'looks_switchbackdropto',
-        'looks_switchbackdroptoandwait',
-        'looks_nextbackdrop',
         'looks_switchcostumeto',
         'looks_nextcostume',
+        'looks_switchbackdropto',
+        'looks_nextbackdrop',
         'looks_changesizeby',
         'looks_setsizeto',
         'looks_changeeffectby',
@@ -78,7 +77,12 @@ export const CATEGORY_BLOCKS = {
         'looks_show',
         'looks_hide',
         'looks_gotofrontback',
-        'looks_goforwardbackwardlayers'
+        'looks_goforwardbackwardlayers',
+        'looks_costumenumbername',
+        'looks_backdropnumbername',
+        'looks_size',
+        // for Stage
+        'looks_switchbackdroptoandwait'
     ],
     sound: [
         'sound_playuntildone',
@@ -162,12 +166,12 @@ export const CATEGORY_BLOCKS = {
  */
 export const initializeBlockSelectionFromOnlyBlocks = onlyBlocks => {
     const selectedBlocks = {};
-    
+
     // Always initialize each category
     Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
         selectedBlocks[categoryId] = [];
     });
-    
+
     // If no onlyBlocks parameter provided (null/undefined), select all blocks (default behavior)
     if (onlyBlocks === null || typeof onlyBlocks === 'undefined') {
         Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
@@ -175,20 +179,20 @@ export const initializeBlockSelectionFromOnlyBlocks = onlyBlocks => {
         });
         return selectedBlocks;
     }
-    
+
     // If empty string provided, return empty selections
     if (!onlyBlocks) return selectedBlocks;
-    
+
     // Parse only_blocks parameter
     const patterns = onlyBlocks.split(/[,.]/)
         .map(pattern => pattern.trim())
         .filter(pattern => pattern.length > 0);
-    
+
     // Process patterns to determine which blocks should be initially selected
     patterns.forEach(pattern => {
         Object.keys(CATEGORY_BLOCKS).forEach(categoryId => {
             const categoryBlocks = CATEGORY_BLOCKS[categoryId] || [];
-            
+
             // Check if pattern matches category prefix (e.g., "motion_" matches motion category)
             if (pattern.endsWith('_') && pattern === `${categoryId}_`) {
                 // Select all blocks in this category
@@ -201,7 +205,7 @@ export const initializeBlockSelectionFromOnlyBlocks = onlyBlocks => {
             }
         });
     });
-    
+
     return selectedBlocks;
 };
 
@@ -313,7 +317,7 @@ class BlockDisplayModal extends React.Component {
     generateOnlyBlocksUrl () {
         const {selectedBlocks} = this.props;
         const currentUrl = typeof window === 'undefined' ? '' : window.location.href;
-        
+
         // Parse current URL to preserve hash
         let baseUrl;
         let hash;
@@ -341,7 +345,7 @@ class BlockDisplayModal extends React.Component {
         // Create new URL with only_blocks parameter using period separator
         const onlyBlocksParam = onlyBlocksList.join('.');
         const newUrl = `${baseUrl}?only_blocks=${encodeURIComponent(onlyBlocksParam)}${hash}`;
-        
+
         return newUrl;
     }
 

--- a/src/components/block-display-modal/icon--clipboard-copy.svg
+++ b/src/components/block-display-modal/icon--clipboard-copy.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Clipboard Copy</title>
+    <desc>Icon representing copy to clipboard action</desc>
+    <g id="clipboard-copy" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <!-- Clipboard background -->
+        <rect id="clipboard-bg" x="2" y="1" width="8" height="11" rx="1" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/>
+        
+        <!-- Clipboard clip -->
+        <rect id="clipboard-clip" x="3.5" y="0" width="3" height="2" rx="0.5" fill="none" stroke="currentColor" stroke-width="1"/>
+        
+        <!-- Document lines -->
+        <line id="line1" x1="3.5" y1="4" x2="8.5" y2="4" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        <line id="line2" x1="3.5" y1="6" x2="8.5" y2="6" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        <line id="line3" x1="3.5" y1="8" x2="8.5" y2="8" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        
+        <!-- Copy document -->
+        <rect id="copy-doc" x="6" y="5" width="8" height="10" rx="1" fill="white" stroke="currentColor" stroke-width="1"/>
+        
+        <!-- Copy document lines -->
+        <line id="copy-line1" x1="7.5" y1="7" x2="12.5" y2="7" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        <line id="copy-line2" x1="7.5" y1="9" x2="12.5" y2="9" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        <line id="copy-line3" x1="7.5" y1="11" x2="12.5" y2="11" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+        <line id="copy-line4" x1="7.5" y1="13" x2="10.5" y2="13" stroke="currentColor" stroke-width="0.8" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/src/containers/block-display-modal.jsx
+++ b/src/containers/block-display-modal.jsx
@@ -23,7 +23,8 @@ const CATEGORY_BLOCKS = {
         'looks_switchbackdroptoandwait', 'looks_nextbackdrop', 'looks_switchcostumeto',
         'looks_nextcostume', 'looks_changesizeby', 'looks_setsizeto', 'looks_changeeffectby',
         'looks_seteffectto', 'looks_cleargraphiceffects', 'looks_show', 'looks_hide',
-        'looks_gotofrontback', 'looks_goforwardbackwardlayers'
+        'looks_gotofrontback', 'looks_goforwardbackwardlayers', 'looks_costumenumbername',
+        'looks_backdropnumbername', 'looks_size'
     ],
     sound: [
         'sound_playuntildone', 'sound_play', 'sound_stopallsounds', 'sound_changeeffectby',

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -629,6 +629,7 @@ class Blocks extends React.Component {
             updateMetrics: updateMetricsProp,
             useCatBlocks,
             workspaceMetrics,
+            selectedBlocks,
             ...props
         } = this.props;
         /* eslint-enable no-unused-vars */

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -382,13 +382,13 @@ class Blocks extends React.Component {
                     selectedBlockIds.push(...categoryBlocks);
                 });
 
-                // Always include variables and myBlocks (they're always visible)
-                selectedBlockIds.push('variables_', 'myBlocks_');
-
+                // Only generate onlyBlocks if some blocks are selected
+                // If no blocks are selected (empty arrays), show all blocks (no filtering)
                 if (selectedBlockIds.length > 0) {
+                    // Always include variables and myBlocks (they're always visible)
+                    selectedBlockIds.push('variables_', 'myBlocks_');
                     onlyBlocks = selectedBlockIds.join(',');
                 }
-
             }
 
             return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,

--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -391,12 +391,14 @@ class Blocks extends React.Component {
                 }
             }
 
+            const isOnlyBlocksSpecified = this.props.selectedBlocks !== null;
             return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,
                 targetSounds.length > 0 ? targetSounds[targetSounds.length - 1].name : '',
                 getColorsForTheme(this.props.theme),
-                onlyBlocks
+                onlyBlocks,
+                isOnlyBlocksSpecified
             );
         } catch {
             return null;

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -768,9 +768,14 @@ const parseOnlyBlocks = function (onlyBlocks) {
 const shouldIncludeBlock = function (blockType, allowedPatterns) {
     if (!allowedPatterns || allowedPatterns.length === 0) return true;
 
-    return allowedPatterns.some(pattern =>
-        blockType === pattern || blockType.startsWith(pattern)
-    );
+    return allowedPatterns.some(pattern => {
+        // Check if pattern is a category prefix (ends with underscore)
+        if (pattern.endsWith('_')) {
+            return blockType.startsWith(pattern);
+        }
+        // Otherwise, require exact match
+        return blockType === pattern;
+    });
 };
 
 /**

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -789,7 +789,11 @@ const filterBlocks = function (categoryXML, allowedPatterns) {
     if (!allowedPatterns || allowedPatterns.length === 0) return categoryXML;
 
     // Extract both block and separator elements while preserving order
-    const elementRegex = /(?:<block[^>]*type="[^"]+"[^>]*(?:\/>|>.*?<\/block>)|<sep[^>]*\/>)/gs;
+    // Improved regex for better inline/normal block syntax matching
+    const inlineBlock = '<block[^>]*type="[^"]+"[^>]*\\/>';
+    const normalBlock = '<block[^>]*type="[^"]+"[^>]*>[\\s\\S]*?<\\/block>';
+    const separator = '<sep[^>]*\\/>';
+    const elementRegex = new RegExp(`(?:${inlineBlock}|${normalBlock}|${separator})`, 'g');
     const elements = categoryXML.match(elementRegex) || [];
 
     const filteredElements = [];

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -779,6 +779,17 @@ const shouldIncludeBlock = function (blockType, allowedPatterns) {
 };
 
 /**
+ * Hides a category completely when no blocks are selected
+ * @param {string} categoryXML - The XML string for a category (unused)
+ * @returns {string} - Empty string to hide the category
+ */
+// eslint-disable-next-line no-unused-vars
+const filterAllBlocks = function (categoryXML) {
+    // When no blocks are selected, return empty string to hide the entire category
+    return '';
+};
+
+/**
  * Filters block XML content based on only_blocks patterns
  * @param {string} categoryXML - The category XML containing blocks
  * @param {Array.<string>} allowedPatterns - Array of allowed patterns
@@ -870,10 +881,12 @@ const filterBlocks = function (categoryXML, allowedPatterns) {
  * @param {?string} soundName -  The name of the default selected sound dropdown.
  * @param {?object} colors - The colors for the theme.
  * @param {?string} onlyBlocks - The only_blocks URL parameter for filtering blocks.
+ * @param {boolean} isOnlyBlocksSpecified - Whether the only_blocks parameter was explicitly provided.
  * @returns {string} - a ScratchBlocks-style XML document for the contents of the toolbox.
  */
 const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categoriesXML = [],
-    costumeName = '', backdropName = '', soundName = '', colors = defaultColors, onlyBlocks = null) {
+    costumeName = '', backdropName = '', soundName = '', colors = defaultColors, onlyBlocks = null,
+    isOnlyBlocksSpecified = false) {
     isStage = isInitialSetup || isStage;
     const gap = [categorySeparator];
 
@@ -912,15 +925,26 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     // Check if this is the default all blocks state (no filtering intended)
     const isDefaultAllBlocks = allowedPatterns.length >= TOTAL_DEFAULT_BLOCKS;
 
-    // Apply filtering to core categories if not default all blocks
-    if (allowedPatterns.length > 0 && !isDefaultAllBlocks) {
-        motionXML = filterBlocks(motionXML, allowedPatterns);
-        looksXML = filterBlocks(looksXML, allowedPatterns);
-        soundXML = filterBlocks(soundXML, allowedPatterns);
-        eventsXML = filterBlocks(eventsXML, allowedPatterns);
-        controlXML = filterBlocks(controlXML, allowedPatterns);
-        sensingXML = filterBlocks(sensingXML, allowedPatterns);
-        operatorsXML = filterBlocks(operatorsXML, allowedPatterns);
+    // Apply filtering to core categories if only_blocks parameter is provided and not default all blocks
+    if (isOnlyBlocksSpecified && !isDefaultAllBlocks) {
+        // Special case: when allowedPatterns is empty, hide all blocks
+        if (allowedPatterns.length === 0) {
+            motionXML = filterAllBlocks(motionXML);
+            looksXML = filterAllBlocks(looksXML);
+            soundXML = filterAllBlocks(soundXML);
+            eventsXML = filterAllBlocks(eventsXML);
+            controlXML = filterAllBlocks(controlXML);
+            sensingXML = filterAllBlocks(sensingXML);
+            operatorsXML = filterAllBlocks(operatorsXML);
+        } else {
+            motionXML = filterBlocks(motionXML, allowedPatterns);
+            looksXML = filterBlocks(looksXML, allowedPatterns);
+            soundXML = filterBlocks(soundXML, allowedPatterns);
+            eventsXML = filterBlocks(eventsXML, allowedPatterns);
+            controlXML = filterBlocks(controlXML, allowedPatterns);
+            sensingXML = filterBlocks(sensingXML, allowedPatterns);
+            operatorsXML = filterBlocks(operatorsXML, allowedPatterns);
+        }
     }
 
     // Build the final XML, only including non-empty categories

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -753,7 +753,8 @@ const xmlClose = '</xml>';
  */
 const parseOnlyBlocks = function (onlyBlocks) {
     if (!onlyBlocks) return [];
-    return onlyBlocks.split(',')
+    // Support both comma (,) and period (.) as separators
+    return onlyBlocks.split(/[,.]/)
         .map(pattern => pattern.trim())
         .filter(pattern => pattern.length > 0);
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -85,7 +85,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_thinkforsecs': 'think (Hmm...) for (2) seconds',
     'gui.smalruby3.blockDisplayModal.looks_think': 'think (Hmm...)',
     'gui.smalruby3.blockDisplayModal.looks_switchbackdropto': 'switch backdrop to (backdrop1 ▼)',
-    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': 'switch backdrop to (backdrop1 ▼) and wait',
+    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': '[Stage]  switch backdrop to (backdrop1 ▼) and wait',
     'gui.smalruby3.blockDisplayModal.looks_nextbackdrop': 'next backdrop',
     'gui.smalruby3.blockDisplayModal.looks_switchcostumeto': 'switch costume to (costume1 ▼)',
     'gui.smalruby3.blockDisplayModal.looks_nextcostume': 'next costume',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -98,6 +98,9 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_hide': 'hide',
     'gui.smalruby3.blockDisplayModal.looks_gotofrontback': 'go to [front ▼] layer',
     'gui.smalruby3.blockDisplayModal.looks_goforwardbackwardlayers': 'go [forward ▼] (1) layers',
+    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'costume [number ▼]',
+    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': 'backdrop [number ▼]',
+    'gui.smalruby3.blockDisplayModal.looks_size': 'size',
 
     // Sound blocks
     'gui.smalruby3.blockDisplayModal.sound_playuntildone': 'play sound (Meow ▼) until done',

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -100,8 +100,8 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_hide': 'かくす',
     'gui.smalruby3.blockDisplayModal.looks_gotofrontback': '[さいぜんめん▼] へいどうする',
     'gui.smalruby3.blockDisplayModal.looks_goforwardbackwardlayers': '(1) そう [てまえにだす▼]',
-    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの (ばんごう▼)',
-    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': 'はいけいの (ばんごう▼)',
+    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの [ばんごう▼]',
+    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': 'はいけいの [ばんごう▼]',
     'gui.smalruby3.blockDisplayModal.looks_size': 'おおきさ',
 
     // Sound blocks

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -87,7 +87,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_thinkforsecs': '(うーん...) と (2) びょうかんがえる',
     'gui.smalruby3.blockDisplayModal.looks_think': '(うーん...) とかんがえる',
     'gui.smalruby3.blockDisplayModal.looks_switchbackdropto': 'はいけいを (はいけい1) にする',
-    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': 'はいけいを (はいけい1) にしてまつ',
+    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': '【すてーじ】はいけいを (はいけい1) にしてまつ',
     'gui.smalruby3.blockDisplayModal.looks_nextbackdrop': 'つぎのはいけいにする',
     'gui.smalruby3.blockDisplayModal.looks_switchcostumeto': 'コスチュームを (コスチューム1▼) にする',
     'gui.smalruby3.blockDisplayModal.looks_nextcostume': 'つぎのコスチュームにする',

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -100,6 +100,9 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_hide': 'かくす',
     'gui.smalruby3.blockDisplayModal.looks_gotofrontback': '[さいぜんめん▼] へいどうする',
     'gui.smalruby3.blockDisplayModal.looks_goforwardbackwardlayers': '(1) そう [てまえにだす▼]',
+    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの (ばんごう▼)',
+    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': 'はいけいの (ばんごう▼)',
+    'gui.smalruby3.blockDisplayModal.looks_size': 'おおきさ',
 
     // Sound blocks
     'gui.smalruby3.blockDisplayModal.sound_playuntildone': 'おわるまで (Meow▼) のおとをならす',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -101,6 +101,9 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_hide': '隠す',
     'gui.smalruby3.blockDisplayModal.looks_gotofrontback': '[最前面▼] へ移動する',
     'gui.smalruby3.blockDisplayModal.looks_goforwardbackwardlayers': '(1) 層 [手前に出す▼]',
+    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの (番号▼)',
+    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': '背景の (番号▼)',
+    'gui.smalruby3.blockDisplayModal.looks_size': '大きさ',
 
     // Sound blocks
     'gui.smalruby3.blockDisplayModal.sound_playuntildone': '終わるまで (Meow▼) の音を鳴らす',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -101,8 +101,8 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_hide': '隠す',
     'gui.smalruby3.blockDisplayModal.looks_gotofrontback': '[最前面▼] へ移動する',
     'gui.smalruby3.blockDisplayModal.looks_goforwardbackwardlayers': '(1) 層 [手前に出す▼]',
-    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの (番号▼)',
-    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': '背景の (番号▼)',
+    'gui.smalruby3.blockDisplayModal.looks_costumenumbername': 'コスチュームの [番号▼]',
+    'gui.smalruby3.blockDisplayModal.looks_backdropnumbername': '背景の [番号▼]',
     'gui.smalruby3.blockDisplayModal.looks_size': '大きさ',
 
     // Sound blocks

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -88,7 +88,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.looks_thinkforsecs': '(うーん...) と (2) 秒考える',
     'gui.smalruby3.blockDisplayModal.looks_think': '(うーん...) と考える',
     'gui.smalruby3.blockDisplayModal.looks_switchbackdropto': '背景を (背景1) にする',
-    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': '背景を (背景1) にして待つ',
+    'gui.smalruby3.blockDisplayModal.looks_switchbackdroptoandwait': '【ステージ】背景を (背景1) にして待つ',
     'gui.smalruby3.blockDisplayModal.looks_nextbackdrop': '次の背景にする',
     'gui.smalruby3.blockDisplayModal.looks_switchcostumeto': 'コスチュームを (コスチューム1▼) にする',
     'gui.smalruby3.blockDisplayModal.looks_nextcostume': '次のコスチュームにする',

--- a/src/reducers/block-display.js
+++ b/src/reducers/block-display.js
@@ -1,50 +1,23 @@
+import queryString from 'query-string';
+import {initializeBlockSelectionFromOnlyBlocks} from '../components/block-display-modal/block-display-modal.jsx';
+
 const SET_SELECTED_BLOCKS = 'scratch-gui/block-display/SET_SELECTED_BLOCKS';
 const SET_MODAL_VISIBLE = 'scratch-gui/block-display/SET_MODAL_VISIBLE';
 
+// Initialize selectedBlocks based on only_blocks parameter if present
+const getInitialSelectedBlocks = () => {
+    // Parse URL parameters
+    const urlParams = typeof window === 'undefined' ?
+        {} : queryString.parse(window.location.search);
+
+    const onlyBlocks = urlParams.only_blocks;
+
+    // Initialize from only_blocks parameter (null if not present, which will select all blocks)
+    return initializeBlockSelectionFromOnlyBlocks(onlyBlocks);
+};
+
 const initialState = {
-    selectedBlocks: {
-        motion: [
-            'motion_movesteps', 'motion_turnright', 'motion_turnleft', 'motion_goto', 'motion_gotoxy',
-            'motion_glideto', 'motion_glidesecstoxy', 'motion_pointindirection', 'motion_pointtowards',
-            'motion_changexby', 'motion_setx', 'motion_changeyby', 'motion_sety', 'motion_ifonedgebounce',
-            'motion_setrotationstyle'
-        ],
-        looks: [
-            'looks_sayforsecs', 'looks_say', 'looks_thinkforsecs', 'looks_think', 'looks_switchbackdropto',
-            'looks_switchbackdroptoandwait', 'looks_nextbackdrop', 'looks_switchcostumeto',
-            'looks_nextcostume', 'looks_changesizeby', 'looks_setsizeto', 'looks_changeeffectby',
-            'looks_seteffectto', 'looks_cleargraphiceffects', 'looks_show', 'looks_hide',
-            'looks_gotofrontback', 'looks_goforwardbackwardlayers'
-        ],
-        sound: [
-            'sound_playuntildone', 'sound_play', 'sound_stopallsounds', 'sound_changeeffectby',
-            'sound_seteffectto', 'sound_cleareffects', 'sound_changevolumeby', 'sound_setvolumeto'
-        ],
-        events: [
-            'event_whenflagclicked', 'event_whenkeypressed', 'event_whenthisspriteclicked',
-            'event_whenbackdropswitchesto', 'event_whengreaterthan', 'event_whenbroadcastreceived',
-            'event_broadcast', 'event_broadcastandwait'
-        ],
-        control: [
-            'control_wait', 'control_repeat', 'control_forever', 'control_if', 'control_if_else',
-            'control_wait_until', 'control_repeat_until', 'control_stop', 'control_start_as_clone',
-            'control_create_clone_of', 'control_delete_this_clone'
-        ],
-        sensing: [
-            'sensing_touchingobject', 'sensing_touchingcolor', 'sensing_coloristouchingcolor',
-            'sensing_distanceto', 'sensing_askandwait', 'sensing_answer', 'sensing_keypressed',
-            'sensing_mousedown', 'sensing_mousex', 'sensing_mousey', 'sensing_setdragmode',
-            'sensing_loudness', 'sensing_timer', 'sensing_resettimer', 'sensing_of',
-            'sensing_current', 'sensing_dayssince2000', 'sensing_username'
-        ],
-        operators: [
-            'operator_add', 'operator_subtract', 'operator_multiply', 'operator_divide',
-            'operator_random', 'operator_gt', 'operator_lt', 'operator_equals', 'operator_and',
-            'operator_or', 'operator_not', 'operator_join', 'operator_letter_of',
-            'operator_length', 'operator_contains', 'operator_mod', 'operator_round',
-            'operator_mathop'
-        ]
-    },
+    selectedBlocks: getInitialSelectedBlocks(),
     modalVisible: false
 };
 

--- a/src/reducers/toolbox.js
+++ b/src/reducers/toolbox.js
@@ -6,7 +6,8 @@ const getInitialToolboxXML = () => {
     try {
         const queryParams = queryString.parse(location.search);
         const onlyBlocks = queryParams.only_blocks;
-        return makeToolboxXML(true, true, null, [], '', '', '', null, onlyBlocks);
+        const isOnlyBlocksSpecified = onlyBlocks !== undefined;
+        return makeToolboxXML(true, true, null, [], '', '', '', null, onlyBlocks, isOnlyBlocksSpecified);
     } catch {
         return makeToolboxXML(true);
     }

--- a/src/reducers/toolbox.js
+++ b/src/reducers/toolbox.js
@@ -6,7 +6,7 @@ const getInitialToolboxXML = () => {
     try {
         const queryParams = queryString.parse(location.search);
         const onlyBlocks = queryParams.only_blocks;
-        const isOnlyBlocksSpecified = onlyBlocks !== undefined;
+        const isOnlyBlocksSpecified = typeof onlyBlocks !== 'undefined';
         return makeToolboxXML(true, true, null, [], '', '', '', null, onlyBlocks, isOnlyBlocksSpecified);
     } catch {
         return makeToolboxXML(true);

--- a/test/integration/block-display-modal.test.js
+++ b/test/integration/block-display-modal.test.js
@@ -92,4 +92,45 @@ describe('Block Display Modal', () => {
         const logs = await getLogs();
         expect(logs).toEqual([]);
     });
+
+    test('URL input field is displayed in block display modal', async () => {
+        await loadUri(uri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+
+        // Click Settings menu
+        await clickXpath(SETTINGS_MENU_XPATH);
+
+        // Click Block Display Settings menu item
+        await clickText('Block Display...', scope.menuBar);
+
+        // Wait for modal to render
+        await driver.sleep(1000);
+
+        // Verify URL label exists
+        await findByText('URL:', scope.modal);
+
+        // Verify URL input field exists
+        const urlInput = await findByXpath('//input[@type="text"][contains(@class, "block-display-modal_urlInput")]');
+        expect(urlInput).toBeTruthy();
+
+        // Verify URL input field is read-only
+        const isReadOnly = await urlInput.getAttribute('readonly');
+        expect(isReadOnly).not.toBeNull();
+
+        // Verify URL input field contains current page URL
+        const urlValue = await urlInput.getAttribute('value');
+        expect(urlValue).toContain('index.html');
+
+        // Close the modal using ESC key
+        await driver.actions().sendKeys("\uE00C").perform();
+
+        // Wait for modal to close
+        await driver.sleep(300);
+
+        // Verify modal is closed
+        await notExistsByXpath('//div[contains(@class, "block-display-modal_blockItem")]');
+
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
 });

--- a/test/integration/block-display-modal.test.js
+++ b/test/integration/block-display-modal.test.js
@@ -133,4 +133,40 @@ describe('Block Display Modal', () => {
         const logs = await getLogs();
         expect(logs).toEqual([]);
     });
+
+    test('URL input field shows generated only_blocks URL when blocks are selected', async () => {
+        await loadUri(uri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+
+        // Click Settings menu
+        await clickXpath(SETTINGS_MENU_XPATH);
+
+        // Click Block Display Settings menu item
+        await clickText('Block Display...', scope.menuBar);
+
+        // Wait for modal to render
+        await driver.sleep(1000);
+
+        // Select a block by clicking its checkbox
+        const motionCheckbox = await findByXpath('//input[@type="checkbox"][@data-block="motion_movesteps"]');
+        await motionCheckbox.click();
+
+        // Wait for URL to update
+        await driver.sleep(500);
+
+        // Verify URL input field contains only_blocks parameter with period separator
+        const urlInput = await findByXpath('//input[@type="text"][contains(@class, "block-display-modal_urlInput")]');
+        const urlValue = await urlInput.getAttribute('value');
+        expect(urlValue).toContain('only_blocks=');
+        expect(urlValue).toContain('motion_movesteps');
+
+        // Close the modal using ESC key
+        await driver.actions().sendKeys("\uE00C").perform();
+
+        // Wait for modal to close
+        await driver.sleep(300);
+
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
 });

--- a/test/integration/block-display-modal.test.js
+++ b/test/integration/block-display-modal.test.js
@@ -266,4 +266,31 @@ describe('Block Display Modal', () => {
         const logs = await getLogs();
         expect(logs).toEqual([]);
     });
+
+    test('should not show looks_sayforsecs when only looks_say is selected (exact match)', async () => {
+        // Test with URL parameter that specifies only looks_say block
+        const testUri = uri + '?only_blocks=looks_say';
+        await loadUri(testUri);
+        await notExistsByXpath('//*[div[contains(@class, "loader_background")]]');
+
+        // Go to Code tab to check block visibility
+        await clickText('Code');
+        await driver.sleep(1000);
+
+        // Click on Looks category to expand it
+        await clickText('Looks');
+        await driver.sleep(1000);
+
+        // looks_say should be visible (it was specified in only_blocks)
+        const sayBlockExists = await textExists('say', scope.blocksTab);
+        expect(sayBlockExists).toBeTruthy();
+
+        // looks_sayforsecs should NOT be visible (exact match required, not prefix match)
+        // This verifies that the prefix matching issue has been fixed
+        const sayForSecsExists = await textExists('say for', scope.blocksTab);
+        expect(sayForSecsExists).toBeFalsy();
+
+        const logs = await getLogs();
+        expect(logs).toEqual([]);
+    });
 });

--- a/test/unit/empty-block-selection.test.js
+++ b/test/unit/empty-block-selection.test.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Test for empty block selection filtering behavior
+ */
+
+import makeToolboxXML from '../../src/lib/make-toolbox-xml';
+import {defaultColors} from '../../src/lib/themes';
+
+describe('Empty block selection filtering', () => {
+    test('should show no blocks when empty allowed patterns are provided', () => {
+        const emptyPatterns = [];
+        const targetId = 'testSprite';
+
+        const xml = makeToolboxXML(false, false, targetId, [], '', '', '', defaultColors, '', true);
+        
+        // When no blocks are selected, no core category blocks should be present
+        expect(xml).not.toContain('type="motion_movesteps"');
+        expect(xml).not.toContain('type="looks_say"');
+        expect(xml).not.toContain('type="sound_play"');
+        expect(xml).not.toContain('type="event_whenflagclicked"');
+        expect(xml).not.toContain('type="control_wait"');
+        expect(xml).not.toContain('type="sensing_touchingobject"');
+        expect(xml).not.toContain('type="operator_add"');
+        
+        // Core categories should be completely hidden (not just empty)
+        expect(xml).not.toContain('BKY_CATEGORY_MOTION');
+        expect(xml).not.toContain('BKY_CATEGORY_LOOKS');
+        expect(xml).not.toContain('BKY_CATEGORY_SOUND');
+        expect(xml).not.toContain('BKY_CATEGORY_EVENTS');
+        expect(xml).not.toContain('BKY_CATEGORY_CONTROL');
+        expect(xml).not.toContain('BKY_CATEGORY_SENSING');
+        expect(xml).not.toContain('BKY_CATEGORY_OPERATORS');
+        
+        // Variables and myBlocks categories should still be present (always visible)
+        expect(xml).toContain('CATEGORY_VARIABLES');
+        expect(xml).toContain('CATEGORY_MYBLOCKS');
+    });
+
+    test('should show all blocks when no only_blocks parameter is provided (null)', () => {
+        const noPatterns = null;
+        const targetId = 'testSprite';
+
+        const xml = makeToolboxXML(false, false, targetId, [], '', '', '', defaultColors, noPatterns, false);
+        
+        // When no only_blocks parameter is provided, all blocks should be present
+        expect(xml).toContain('type="motion_movesteps"');
+        expect(xml).toContain('type="looks_say"');
+        expect(xml).toContain('type="sound_play"');
+        expect(xml).toContain('type="event_whenflagclicked"');
+        expect(xml).toContain('type="control_wait"');
+        expect(xml).toContain('type="sensing_touchingobject"');
+        expect(xml).toContain('type="operator_add"');
+    });
+});

--- a/test/unit/make-toolbox-xml-exact-match.test.js
+++ b/test/unit/make-toolbox-xml-exact-match.test.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Test for exact match logic in make-toolbox-xml shouldIncludeBlock function
+ */
+
+// Import the function we want to test
+// Note: Since shouldIncludeBlock is not exported, we'll create a test version
+const shouldIncludeBlockExactMatch = function (blockType, allowedPatterns) {
+    if (!allowedPatterns || allowedPatterns.length === 0) return true;
+
+    return allowedPatterns.some(pattern => {
+        // Check if pattern is a category prefix (ends with underscore)
+        if (pattern.endsWith('_')) {
+            return blockType.startsWith(pattern);
+        }
+        // Otherwise, require exact match
+        return blockType === pattern;
+    });
+};
+
+describe('shouldIncludeBlock exact match logic', () => {
+    test('should include block with exact match', () => {
+        const result = shouldIncludeBlockExactMatch('looks_say', ['looks_say']);
+        expect(result).toBeTruthy();
+    });
+
+    test('should not include block with prefix match when exact match is required', () => {
+        // This test shows the desired behavior: looks_sayforsecs should NOT be included
+        // when only looks_say is in the allowed patterns
+        const result = shouldIncludeBlockExactMatch('looks_sayforsecs', ['looks_say']);
+        expect(result).toBeFalsy();
+    });
+
+    test('should include block with category prefix match', () => {
+        // Category prefixes (ending with _) should still work with startsWith
+        const result = shouldIncludeBlockExactMatch('looks_say', ['looks_']);
+        expect(result).toBeTruthy();
+    });
+
+    test('should include multiple blocks with category prefix', () => {
+        const result1 = shouldIncludeBlockExactMatch('looks_say', ['looks_']);
+        const result2 = shouldIncludeBlockExactMatch('looks_sayforsecs', ['looks_']);
+        expect(result1).toBeTruthy();
+        expect(result2).toBeTruthy();
+    });
+
+    test('should handle multiple exact matches', () => {
+        const result = shouldIncludeBlockExactMatch('looks_say', ['motion_movesteps', 'looks_say', 'sound_play']);
+        expect(result).toBeTruthy();
+    });
+
+    test('should reject blocks not in allowed patterns', () => {
+        const result = shouldIncludeBlockExactMatch('looks_think', ['looks_say', 'motion_movesteps']);
+        expect(result).toBeFalsy();
+    });
+
+    test('should return true for empty or null allowed patterns', () => {
+        const result1 = shouldIncludeBlockExactMatch('looks_say', []);
+        const result2 = shouldIncludeBlockExactMatch('looks_say', null);
+        expect(result1).toBeTruthy();
+        expect(result2).toBeTruthy();
+    });
+
+    test('should demonstrate current problematic behavior with prefix matching', () => {
+        // This test demonstrates the current problem: looks_sayforsecs gets included
+        // when looks_say is specified due to startsWith logic
+        const currentShouldIncludeBlock = function (blockType, allowedPatterns) {
+            if (!allowedPatterns || allowedPatterns.length === 0) return true;
+            return allowedPatterns.some(pattern =>
+                blockType === pattern || blockType.startsWith(pattern)
+            );
+        };
+
+        // This currently returns true (problematic behavior)
+        const problematicResult = currentShouldIncludeBlock('looks_sayforsecs', ['looks_say']);
+        expect(problematicResult).toBeTruthy(); // This shows the current problem
+
+        // This is the desired behavior (should return false)
+        const correctResult = shouldIncludeBlockExactMatch('looks_sayforsecs', ['looks_say']);
+        expect(correctResult).toBeFalsy(); // This shows the desired behavior
+    });
+});

--- a/test/unit/only-blocks-initialization.test.js
+++ b/test/unit/only-blocks-initialization.test.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Test for only_blocks parameter initialization logic
+ */
+
+import {CATEGORY_BLOCKS, initializeBlockSelectionFromOnlyBlocks} from '../../src/components/block-display-modal/block-display-modal.jsx';
+
+describe('only_blocks parameter initialization', () => {
+    test('should initialize with all blocks selected when no only_blocks parameter (default behavior)', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks(null);
+        expect(result).toEqual({
+            motion: CATEGORY_BLOCKS.motion,
+            looks: CATEGORY_BLOCKS.looks,
+            sound: CATEGORY_BLOCKS.sound,
+            events: CATEGORY_BLOCKS.events,
+            control: CATEGORY_BLOCKS.control,
+            sensing: CATEGORY_BLOCKS.sensing,
+            operators: CATEGORY_BLOCKS.operators
+        });
+    });
+
+    test('should initialize empty selection when empty string is provided', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('');
+        expect(result).toEqual({
+            motion: [],
+            looks: [],
+            sound: [],
+            events: [],
+            control: [],
+            sensing: [],
+            operators: []
+        });
+    });
+
+    test('should select all motion blocks when "motion_" is specified', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_');
+        expect(result.motion).toEqual(CATEGORY_BLOCKS.motion);
+        expect(result.looks).toEqual([]);
+        expect(result.sound).toEqual([]);
+    });
+
+    test('should select specific block when exact block ID is specified', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_movesteps');
+        expect(result.motion).toEqual(['motion_movesteps']);
+        expect(result.looks).toEqual([]);
+    });
+
+    test('should handle multiple categories with underscore suffix', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_.looks_');
+        expect(result.motion).toEqual(CATEGORY_BLOCKS.motion);
+        expect(result.looks).toEqual(CATEGORY_BLOCKS.looks);
+        expect(result.sound).toEqual([]);
+    });
+
+    test('should handle mix of category and specific block selections', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_.looks_say.sound_play');
+        expect(result.motion).toEqual(CATEGORY_BLOCKS.motion);
+        expect(result.looks).toEqual(['looks_say']);
+        expect(result.sound).toEqual(['sound_play']);
+    });
+
+    test('should not have prefix matching issues - looks_say should not affect looks_sayforsecs', () => {
+        // When only looks_say is specified, looks_sayforsecs should NOT be selected
+        const result = initializeBlockSelectionFromOnlyBlocks('looks_say');
+        expect(result.looks).toEqual(['looks_say']);
+        expect(result.looks).not.toContain('looks_sayforsecs');
+    });
+
+    test('should work with comma separator', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_movesteps,looks_say');
+        expect(result.motion).toEqual(['motion_movesteps']);
+        expect(result.looks).toEqual(['looks_say']);
+    });
+
+    test('should work with period separator', () => {
+        const result = initializeBlockSelectionFromOnlyBlocks('motion_movesteps.looks_say');
+        expect(result.motion).toEqual(['motion_movesteps']);
+        expect(result.looks).toEqual(['looks_say']);
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds a URL pane to the block display modal and includes several important bug fixes for block filtering functionality.

### New Features
- **URL Pane**: Added a URL pane at the bottom of the block display modal that shows the generated `only_blocks` parameter URL
- **URL Generation**: Implements period-separated `only_blocks` parameter generation for better compatibility
- **Block Selection Initialization**: Added proper initialization of block selection from URL parameters

### Bug Fixes
- **Block Filtering Bug**: Fixed critical bug where unchecking all blocks still showed all blocks instead of hiding them
- **Category Checkbox Bug**: Fixed bug where newly added looks blocks weren't included in category checkbox operations  
- **Empty Category Hiding**: Fixed regression where empty categories showed headers instead of being completely hidden
- **Prefix Matching**: Improved prefix matching logic for exact vs partial block matching
- **Inline Block Syntax**: Enhanced regex pattern for better handling of inline block XML syntax

### Technical Details
- Added `isOnlyBlocksSpecified` flag to distinguish between no parameter vs empty parameter
- Enhanced `filterBlocks` and added `filterAllBlocks` functions for proper category hiding
- Added missing blocks to container's `CATEGORY_BLOCKS` array:
  - `looks_costumenumbername`
  - `looks_backdropnumbername`
  - `looks_size`
- Implemented comprehensive test coverage for empty block selection behavior
- Added message catalog entries for newly added blocks

### Block Order Improvements
- Reordered looks category blocks to match authoritative `make-toolbox-xml.js` order
- Added Stage prefixes to Stage-specific blocks in all locales (English, Japanese, Hiragana)
- Fixed bracket notation in Japanese locale files

### UI/UX Improvements  
- Modal height increased from 560px to 625px to accommodate URL pane
- Responsive layout with flexbox for better space utilization
- URL input field with proper focus styling and monospace font
- Read-only URL field for easy copying

## Test Plan
- [x] URL pane displays correct `only_blocks` parameter based on selections
- [x] Block filtering works correctly when all blocks are unchecked (shows no blocks)
- [x] Block filtering works correctly when no parameter provided (shows all blocks)
- [x] Category checkboxes properly include/exclude newly added looks blocks
- [x] Empty categories are completely hidden (no headers shown)
- [x] Stage-specific blocks show appropriate prefixes in all locales
- [x] All existing functionality remains intact
- [x] Lint and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)