### PR TITLE
feat: add variable scope validation in Ruby-to-Blocks converter

### DIFF
--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -45,6 +45,11 @@ const messages = defineMessages({
         defaultMessage: '"{ SOURCE }" is the wrong instruction.',
         description: 'Error message for converting ruby to block when find the wrong instruction',
         id: 'gui.smalruby3.rubyToBlocksConverter.wrongInstruction'
+    },
+    cannotChangeVariableScope: {
+        defaultMessage: '"{ VARIABLE }", can\'t change variable scope',
+        description: 'Error message when trying to change variable scope from global to instance or vice versa',
+        id: 'gui.smalruby3.rubyToBlocksConverter.cannotChangeVariableScope'
     }
 });
 
@@ -846,7 +851,15 @@ class RubyToBlocksConverter {
             storeName = 'lists';
         }
         let variable = this._context[storeName][varName];
-        if (!variable) {
+        if (variable) {
+            // Check for variable scope change - only for global/instance variables
+            if ((scope === 'global' || scope === 'instance') && variable.scope !== scope) {
+                throw new RubyToBlocksConverterError(
+                    this._context.currentNode,
+                    `"${name}", can't change variable scope`
+                );
+            }
+        } else {
             variable = {
                 id: Blockly.utils.genUid(),
                 name: varName,


### PR DESCRIPTION
## Summary

Implements variable scope change detection and validation in the Ruby-to-Blocks converter to prevent users from accidentally changing existing variable scopes between global ($) and instance (@) types.

## Implementation Details

### Core Changes
- **Modified `_lookupOrCreateVariableOrList` method** in `src/lib/ruby-to-blocks-converter/index.js`
  - Added scope validation logic that checks if an existing variable's scope matches the requested scope
  - Throws `RubyToBlocksConverterError` when scope mismatch is detected
  - Only validates global ($) and instance (@) variables as these are the only scoped variable types supported by smalruby

### Error Handling
- **Error message format**: `"variable_name", can't change variable scope`
- Uses direct string interpolation for consistent error formatting
- Triggers conversion error workflow (highlights target, activates Ruby tab, shows alert)

### Validation Logic
- ✅ **Allows**: Same-scope variable reuse (global → global, instance → instance)  
- ✅ **Allows**: Creating new variables with different names and scopes
- ❌ **Prevents**: Changing existing variable from global ($) to instance (@)
- ❌ **Prevents**: Changing existing variable from instance (@) to global ($)

## Test Coverage

Added comprehensive test suite in `test/unit/lib/ruby-to-blocks-converter/variables.test.js`:

- **Global to Instance Error**: Tests error when trying to use existing global variable as instance variable
- **Instance to Global Error**: Tests error when trying to use existing instance variable as global variable  
- **Same Scope Reuse**: Confirms global/instance variables can be reused with same scope
- **Variable Reading**: Tests scope validation applies to variable reading (not just assignment)
- **New Variable Creation**: Confirms new variables with different names can be created regardless of scope

All tests use proper `Variable.SCALAR_TYPE` constants and realistic mock targets.

## Usage Examples

### Error Cases
```ruby
# Existing global variable $score
@score = 100  # ERROR: "score", can't change variable scope

# Existing instance variable @health  
$health = 50  # ERROR: "health", can't change variable scope
```

### Valid Cases
```ruby
# Reusing same scope
$score = 100    # OK: global variable reused as global
@health = 50    # OK: instance variable reused as instance

# New variables
$new_global = 0     # OK: new global variable
@new_instance = 0   # OK: new instance variable
```

## Quality Assurance

- ✅ **All tests passing**: 40/40 tests pass including 6 new scope validation tests
- ✅ **Lint clean**: No ESLint errors or warnings  
- ✅ **Code style**: Follows existing patterns and conventions
- ✅ **Backward compatible**: No breaking changes to existing functionality

Fixes #169

🤖 Generated with [Claude Code](https://claude.ai/code)