### PR TITLE
refactor: rename registerCallMethod* to registerOnSend* for consistency

### DIFF
--- a/src/lib/ruby-to-blocks-converter/boost.js
+++ b/src/lib/ruby-to-blocks-converter/boost.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
  */
 const BoostConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', 'boost_motor_turn_on_for', 2, params => {
+        converter.registerOnSend('self', 'boost_motor_turn_on_for', 2, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
 
@@ -19,7 +19,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_turn_on_for', 1, params => {
+        converter.registerOnSend('self', 'boost_motor_turn_on_for', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -32,7 +32,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_turn_this_way_for', 2, params => {
+        converter.registerOnSend('self', 'boost_motor_turn_this_way_for', 2, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
 
@@ -46,7 +46,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_turn_off_for', 1, params => {
+        converter.registerOnSend('self', 'boost_motor_turn_off_for', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -59,7 +59,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_set_power_for', 2, params => {
+        converter.registerOnSend('self', 'boost_motor_set_power_for', 2, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
 
@@ -73,7 +73,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_set_direction_for', 2, params => {
+        converter.registerOnSend('self', 'boost_motor_set_direction_for', 2, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0]) || !converter.isStringOrBlock(args[1])) return null;
 
@@ -91,7 +91,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_motor_get_position', 1, params => {
+        converter.registerOnSend('self', 'boost_motor_get_position', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -104,7 +104,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_seeing_color?', 1, params => {
+        converter.registerOnSend('self', 'boost_seeing_color?', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -117,7 +117,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_get_tilt_angle', 1, params => {
+        converter.registerOnSend('self', 'boost_get_tilt_angle', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -130,7 +130,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'boost_set_light_color', 1, params => {
+        converter.registerOnSend('self', 'boost_set_light_color', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -139,7 +139,7 @@ const BoostConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args, rubyBlock} = params;
 
             if (args[0].type !== 'sym' || !converter.isStringOrBlock(args[1])) return null;

--- a/src/lib/ruby-to-blocks-converter/control.js
+++ b/src/lib/ruby-to-blocks-converter/control.js
@@ -22,7 +22,7 @@ const ControlConverter = {
 
     register: function (converter) {
         // sleep(duration) - control_wait
-        converter.registerCallMethod('self', 'sleep', 1, params => {
+        converter.registerOnSend('self', 'sleep', 1, params => {
             const {args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -32,7 +32,7 @@ const ControlConverter = {
         });
 
         // repeat(times) { block } - control_repeat
-        converter.registerCallMethodWithBlock('self', 'repeat', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'repeat', 1, 0, params => {
             const {args, rubyBlock} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -42,7 +42,7 @@ const ControlConverter = {
 
         // loop { block } and forever { block } - control_forever
         ['loop', 'forever'].forEach(methodName => {
-            converter.registerCallMethodWithBlock('self', methodName, 0, 0, params => {
+            converter.registerOnSendWithBlock('self', methodName, 0, 0, params => {
                 const {rubyBlock} = params;
                 if (!rubyBlock) return null;
 
@@ -54,7 +54,7 @@ const ControlConverter = {
         });
 
         // stop(option) - control_stop
-        converter.registerCallMethod('self', 'stop', 1, params => {
+        converter.registerOnSend('self', 'stop', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0]) || StopOptions.indexOf(args[0].toString()) < 0) return null;
 
@@ -64,7 +64,7 @@ const ControlConverter = {
         });
 
         // create_clone(target) - control_create_clone_of
-        converter.registerCallMethod('self', 'create_clone', 1, params => {
+        converter.registerOnSend('self', 'create_clone', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -78,7 +78,7 @@ const ControlConverter = {
         });
 
         // number.times { block } and variable.times { block } - control_repeat
-        converter.registerCallMethodWithBlock('any', 'times', 0, 0, params => {
+        converter.registerOnSendWithBlock('any', 'times', 0, 0, params => {
             const {receiver, rubyBlock} = params;
             if (!rubyBlock || !converter._isNumberOrBlock(receiver)) return null;
 
@@ -87,7 +87,7 @@ const ControlConverter = {
         });
 
         // when_start_as_a_clone { block } (sprite only)
-        converter.registerCallMethodWithBlock('sprite', 'when_start_as_a_clone', 0, 0, params => {
+        converter.registerOnSendWithBlock('sprite', 'when_start_as_a_clone', 0, 0, params => {
             const {rubyBlock} = params;
             const block = converter.createBlock('control_start_as_clone', 'hat');
             converter.setParent(rubyBlock, block);
@@ -95,12 +95,12 @@ const ControlConverter = {
         });
 
         // delete_this_clone method (sprite only)
-        converter.registerCallMethod('sprite', 'delete_this_clone', 0, () =>
+        converter.registerOnSend('sprite', 'delete_this_clone', 0, () =>
             converter._createBlock('control_delete_this_clone', 'statement')
         );
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 1, 0, params => {
             const {args} = params;
 
             if (args[0].type !== 'sym') return null;

--- a/src/lib/ruby-to-blocks-converter/ev3.js
+++ b/src/lib/ruby-to-blocks-converter/ev3.js
@@ -9,13 +9,13 @@ const Ev3SensorMenu = ['1', '2', '3', '4'];
  */
 const EV3Converter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Ev3, 0, params => {
+        converter.registerOnSend('self', Ev3, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Ev3, node);
         });
 
-        converter.registerCallMethod(Ev3, 'motor_turn_this_way_for', 2, params => {
+        converter.registerOnSend(Ev3, 'motor_turn_this_way_for', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -32,7 +32,7 @@ const EV3Converter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_motor_turn_this_way_for', 2, params => {
+        converter.registerOnSend('self', 'ev3_motor_turn_this_way_for', 2, params => {
             const {args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -48,7 +48,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'motor_turn_that_way_for', 2, params => {
+        converter.registerOnSend(Ev3, 'motor_turn_that_way_for', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -64,7 +64,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'motor_turn_that_way_for', 2, params => {
+        converter.registerOnSend(Ev3, 'motor_turn_that_way_for', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -80,7 +80,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'motor_turn_that_way_for', 2, params => {
+        converter.registerOnSend(Ev3, 'motor_turn_that_way_for', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -98,7 +98,7 @@ const EV3Converter = {
 
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_motor_turn_that_way_for', 2, params => {
+        converter.registerOnSend('self', 'ev3_motor_turn_that_way_for', 2, params => {
             const {args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -114,7 +114,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'motor_set_power', 2, params => {
+        converter.registerOnSend(Ev3, 'motor_set_power', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -132,7 +132,7 @@ const EV3Converter = {
 
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_motor_set_power', 2, params => {
+        converter.registerOnSend('self', 'ev3_motor_set_power', 2, params => {
             const {args} = params;
 
             if (!converter.isString(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -148,7 +148,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'motor_position', 1, params => {
+        converter.registerOnSend(Ev3, 'motor_position', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -164,7 +164,7 @@ const EV3Converter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_motor_position', 1, params => {
+        converter.registerOnSend('self', 'ev3_motor_position', 1, params => {
             const {args} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -179,7 +179,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'button_pressed?', 1, params => {
+        converter.registerOnSend(Ev3, 'button_pressed?', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -195,7 +195,7 @@ const EV3Converter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_button_pressed?', 1, params => {
+        converter.registerOnSend('self', 'ev3_button_pressed?', 1, params => {
             const {args} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -210,29 +210,29 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Ev3, 'distance', 0, params => {
+        converter.registerOnSend(Ev3, 'distance', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'ev3_getDistance', 'value');
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_distance', 0, () =>
+        converter.registerOnSend('self', 'ev3_distance', 0, () =>
             converter.createBlock('ev3_getDistance', 'value')
         );
 
-        converter.registerCallMethod(Ev3, 'brightness', 0, params => {
+        converter.registerOnSend(Ev3, 'brightness', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'ev3_getBrightness', 'value');
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_brightness', 0, () =>
+        converter.registerOnSend('self', 'ev3_brightness', 0, () =>
             converter.createBlock('ev3_getBrightness', 'value')
         );
 
-        converter.registerCallMethod(Ev3, 'beep_note', 2, params => {
+        converter.registerOnSend(Ev3, 'beep_note', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isNumberOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -244,7 +244,7 @@ const EV3Converter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('self', 'ev3_beep_note', 2, params => {
+        converter.registerOnSend('self', 'ev3_beep_note', 2, params => {
             const {args} = params;
 
             if (!converter.isNumberOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -255,7 +255,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Ev3, 'when_button_pressed', 1, 0, params => {
+        converter.registerOnSendWithBlock(Ev3, 'when_button_pressed', 1, 0, params => {
             console.log(Ev3, 'when_button_pressed', 1, 0, params);
             const {receiver, args, rubyBlock} = params;
 
@@ -277,7 +277,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Ev3, 'when_distance_lt', 1, 0, params => {
+        converter.registerOnSendWithBlock(Ev3, 'when_distance_lt', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -288,7 +288,7 @@ const EV3Converter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Ev3, 'when_brightness_lt', 1, 0, params => {
+        converter.registerOnSendWithBlock(Ev3, 'when_brightness_lt', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -300,7 +300,7 @@ const EV3Converter = {
         });
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args, rubyBlock} = params;
 
             if (args[0].type !== 'sym') return null;

--- a/src/lib/ruby-to-blocks-converter/event.js
+++ b/src/lib/ruby-to-blocks-converter/event.js
@@ -12,7 +12,7 @@ const GreaterThanMenu = [
  */
 const EventConverter = {
     register: function (converter) {
-        converter.registerCallMethodWithBlock('self', 'when_flag_clicked', 0, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_flag_clicked', 0, 0, params => {
             const {rubyBlock} = params;
 
             const block = converter.createBlock('event_whenflagclicked', 'hat');
@@ -20,7 +20,7 @@ const EventConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when_key_pressed', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_key_pressed', 1, 0, params => {
             const {args, rubyBlock} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -32,7 +32,7 @@ const EventConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when_clicked', 0, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_clicked', 0, 0, params => {
             const {receiverName, rubyBlock} = params;
 
             let opcode = 'event_whenthisspriteclicked';
@@ -42,7 +42,7 @@ const EventConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when_backdrop_switches', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_backdrop_switches', 1, 0, params => {
             const {args, rubyBlock} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -53,7 +53,7 @@ const EventConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when_greater_than', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_greater_than', 2, 0, params => {
             const {args, rubyBlock} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -68,7 +68,7 @@ const EventConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock('self', 'when_receive', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when_receive', 1, 0, params => {
             const {args, rubyBlock} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -112,17 +112,17 @@ const EventConverter = {
             converter.addInput(block, 'BROADCAST_INPUT', inputBlock, shadowBlock);
             return block;
         };
-        converter.registerCallMethod(
+        converter.registerOnSend(
             'self', 'broadcast', 1,
             params => createBroadcastBlockFunc(params, 'event_broadcast')
         );
-        converter.registerCallMethod(
+        converter.registerOnSend(
             'self', 'broadcast_and_wait', 1,
             params => createBroadcastBlockFunc(params, 'event_broadcastandwait')
         );
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 1, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 1, 0, params => {
             const {args} = params;
 
             if (args[0].type !== 'sym') return null;
@@ -144,7 +144,7 @@ const EventConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args} = params;
 
             if (args[0].type !== 'sym') return null;
@@ -171,7 +171,7 @@ const EventConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 3, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 3, 0, params => {
             const {args} = params;
 
             if (args[0].type !== 'sym') return null;

--- a/src/lib/ruby-to-blocks-converter/gdx_for.js
+++ b/src/lib/ruby-to-blocks-converter/gdx_for.js
@@ -8,14 +8,14 @@ const GdxFor = 'gdx_for';
 const GdxForConverter = {
     register: function (converter) {
         // Create the initial Ruby expression block
-        converter.registerCallMethod('self', GdxFor, 0, params => {
+        converter.registerOnSend('self', GdxFor, 0, params => {
             const {node} = params;
             
             return converter.createRubyExpressionBlock(GdxFor, node);
         });
 
         // New Ruby expression pattern methods
-        converter.registerCallMethod(GdxFor, 'acceleration', 1, params => {
+        converter.registerOnSend(GdxFor, 'acceleration', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -29,13 +29,13 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod(GdxFor, 'force', 0, params => {
+        converter.registerOnSend(GdxFor, 'force', 0, params => {
             const {receiver} = params;
             
             return converter.changeRubyExpressionBlock(receiver, 'gdxfor_getForce', 'value');
         });
 
-        converter.registerCallMethod(GdxFor, 'tilted?', 1, params => {
+        converter.registerOnSend(GdxFor, 'tilted?', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -49,7 +49,7 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod(GdxFor, 'tilt_angle', 1, params => {
+        converter.registerOnSend(GdxFor, 'tilt_angle', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -63,13 +63,13 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod(GdxFor, 'falling?', 0, params => {
+        converter.registerOnSend(GdxFor, 'falling?', 0, params => {
             const {receiver} = params;
             
             return converter.changeRubyExpressionBlock(receiver, 'gdxfor_isFreeFalling', 'value');
         });
 
-        converter.registerCallMethod(GdxFor, 'spin_speed', 1, params => {
+        converter.registerOnSend(GdxFor, 'spin_speed', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -84,7 +84,7 @@ const GdxForConverter = {
         });
 
         // New Ruby expression pattern event handlers
-        converter.registerCallMethodWithBlock(GdxFor, 'when_gesture', 1, 0, params => {
+        converter.registerOnSendWithBlock(GdxFor, 'when_gesture', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -99,7 +99,7 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(GdxFor, 'when_sensor', 1, 0, params => {
+        converter.registerOnSendWithBlock(GdxFor, 'when_sensor', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -114,7 +114,7 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(GdxFor, 'when_tilted', 1, 0, params => {
+        converter.registerOnSendWithBlock(GdxFor, 'when_tilted', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -130,7 +130,7 @@ const GdxForConverter = {
         });
 
         // Backward compatibility - old API support
-        converter.registerCallMethod('self', 'gdx_for_acceleration', 1, params => {
+        converter.registerOnSend('self', 'gdx_for_acceleration', 1, params => {
             const {args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -144,11 +144,11 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'gdx_for_force', 0, () =>
+        converter.registerOnSend('self', 'gdx_for_force', 0, () =>
             converter.createBlock('gdxfor_getForce', 'value')
         );
 
-        converter.registerCallMethod('self', 'gdx_for_tilted?', 1, params => {
+        converter.registerOnSend('self', 'gdx_for_tilted?', 1, params => {
             const {args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -162,7 +162,7 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'gdx_for_tilt_angle', 1, params => {
+        converter.registerOnSend('self', 'gdx_for_tilt_angle', 1, params => {
             const {args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -176,11 +176,11 @@ const GdxForConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'gdx_for_falling?', 0, () =>
+        converter.registerOnSend('self', 'gdx_for_falling?', 0, () =>
             converter.createBlock('gdxfor_isFreeFalling', 'value')
         );
 
-        converter.registerCallMethod('self', 'gdx_for_spin_speed', 1, params => {
+        converter.registerOnSend('self', 'gdx_for_spin_speed', 1, params => {
             const {args} = params;
             
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -195,7 +195,7 @@ const GdxForConverter = {
         });
 
         // Backward compatibility - old event handlers
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args, rubyBlock} = params;
             
             if (args[0].type !== 'sym' || !converter.isStringOrBlock(args[1])) return null;

--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -292,24 +292,24 @@ class RubyToBlocksConverter {
         });
     }
 
-    registerCallMethodWithBlock (receiverName, name, numArgs, numRubyBlockArgs, createBlockFunc) {
+    registerOnSendWithBlock (receiverName, name, numArgs, numRubyBlockArgs, createBlockFunc) {
         if (receiverName === 'any') {
             this._anyReceiverNames().forEach(rn => {
-                this.registerCallMethodWithBlock(rn, name, numArgs, numRubyBlockArgs, createBlockFunc);
+                this.registerOnSendWithBlock(rn, name, numArgs, numRubyBlockArgs, createBlockFunc);
             });
             return;
         }
 
         if (_.isArray(receiverName)) {
             receiverName.forEach(rn => {
-                this.registerCallMethodWithBlock(rn, name, numArgs, numRubyBlockArgs, createBlockFunc);
+                this.registerOnSendWithBlock(rn, name, numArgs, numRubyBlockArgs, createBlockFunc);
             });
             return;
         }
 
         if (receiverName === 'self') {
-            this.registerCallMethodWithBlock('sprite', name, numArgs, numRubyBlockArgs, createBlockFunc);
-            this.registerCallMethodWithBlock('stage', name, numArgs, numRubyBlockArgs, createBlockFunc);
+            this.registerOnSendWithBlock('sprite', name, numArgs, numRubyBlockArgs, createBlockFunc);
+            this.registerOnSendWithBlock('stage', name, numArgs, numRubyBlockArgs, createBlockFunc);
             return;
         }
 
@@ -330,24 +330,24 @@ class RubyToBlocksConverter {
         createBlockFuncs.push(createBlockFunc);
     }
 
-    registerCallMethod (receiverName, name, numArgs, createBlockFunc) {
-        this.registerCallMethodWithBlock(receiverName, name, numArgs, 'none', createBlockFunc);
+    registerOnSend (receiverName, name, numArgs, createBlockFunc) {
+        this.registerOnSendWithBlock(receiverName, name, numArgs, 'none', createBlockFunc);
     }
 
-    registerCallMyBlock (receiverName, myBlockHandler) {
+    registerOnSendMyBlock (receiverName, myBlockHandler) {
         if (receiverName === 'any') {
-            this._anyReceiverNames().forEach(rn => this.registerCallMyBlock(rn, myBlockHandler));
+            this._anyReceiverNames().forEach(rn => this.registerOnSendMyBlock(rn, myBlockHandler));
             return;
         }
 
         if (_.isArray(receiverName)) {
-            receiverName.forEach(rn => this.registerCallMyBlock(rn, myBlockHandler));
+            receiverName.forEach(rn => this.registerOnSendMyBlock(rn, myBlockHandler));
             return;
         }
 
         if (receiverName === 'self') {
-            this.registerCallMyBlock('sprite', myBlockHandler);
-            this.registerCallMyBlock('stage', myBlockHandler);
+            this.registerOnSendMyBlock('sprite', myBlockHandler);
+            this.registerOnSendMyBlock('stage', myBlockHandler);
             return;
         }
 

--- a/src/lib/ruby-to-blocks-converter/koshien.js
+++ b/src/lib/ruby-to-blocks-converter/koshien.js
@@ -2,13 +2,13 @@ const Koshien = 'koshien';
 
 const KoshienConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Koshien, 0, params => {
+        converter.registerOnSend('self', Koshien, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Koshien, node);
         });
 
-        converter.registerCallMethod(Koshien, 'connect_game', 1, params => {
+        converter.registerOnSend(Koshien, 'connect_game', 1, params => {
             const {receiver, args} = params;
 
             const name = args[0].get('sym:name');
@@ -28,7 +28,7 @@ const KoshienConverter = {
             return x >= 0 && x <= 14 && y >= 0 && y <= 14;
         };
 
-        converter.registerCallMethod(Koshien, 'get_map_area', 1, params => {
+        converter.registerOnSend(Koshien, 'get_map_area', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -38,7 +38,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'map', 1, params => {
+        converter.registerOnSend(Koshien, 'map', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -48,7 +48,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'move_to', 1, params => {
+        converter.registerOnSend(Koshien, 'move_to', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -58,7 +58,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'calc_route', 1, params => {
+        converter.registerOnSend(Koshien, 'calc_route', 1, params => {
             const {receiver, args} = params;
 
             const src = args[0].get('sym:src');
@@ -90,7 +90,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'set_dynamite', 1, params => {
+        converter.registerOnSend(Koshien, 'set_dynamite', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -101,7 +101,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'set_bomb', 1, params => {
+        converter.registerOnSend(Koshien, 'set_bomb', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -112,13 +112,13 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'map_all', 0, params => {
+        converter.registerOnSend(Koshien, 'map_all', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'koshien_mapAll', 'value');
         });
 
-        converter.registerCallMethod(Koshien, 'map_from', 2, params => {
+        converter.registerOnSend(Koshien, 'map_from', 2, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -131,7 +131,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'locate_objects', 1, params => {
+        converter.registerOnSend(Koshien, 'locate_objects', 1, params => {
             const {receiver, args} = params;
 
             const sqSize = args[0].get('sym:sq_size');
@@ -153,7 +153,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'other_player', 0, params => {
+        converter.registerOnSend(Koshien, 'other_player', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'other_player');
@@ -161,7 +161,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'other_player_x', 0, params => {
+        converter.registerOnSend(Koshien, 'other_player_x', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'other_player');
@@ -169,7 +169,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'other_player_y', 0, params => {
+        converter.registerOnSend(Koshien, 'other_player_y', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'other_player');
@@ -177,7 +177,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'enemy', 0, params => {
+        converter.registerOnSend(Koshien, 'enemy', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'enemy');
@@ -185,7 +185,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'enemy_x', 0, params => {
+        converter.registerOnSend(Koshien, 'enemy_x', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'enemy');
@@ -193,7 +193,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'enemy_y', 0, params => {
+        converter.registerOnSend(Koshien, 'enemy_y', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'enemy');
@@ -201,7 +201,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'goal', 0, params => {
+        converter.registerOnSend(Koshien, 'goal', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'goal');
@@ -209,7 +209,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'goal_x', 0, params => {
+        converter.registerOnSend(Koshien, 'goal_x', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'goal');
@@ -217,7 +217,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'goal_y', 0, params => {
+        converter.registerOnSend(Koshien, 'goal_y', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'goal');
@@ -225,7 +225,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'player', 0, params => {
+        converter.registerOnSend(Koshien, 'player', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'player');
@@ -233,7 +233,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'player_x', 0, params => {
+        converter.registerOnSend(Koshien, 'player_x', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'player');
@@ -241,7 +241,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'player_y', 0, params => {
+        converter.registerOnSend(Koshien, 'player_y', 0, params => {
             const {receiver} = params;
             const block = converter.changeRubyExpressionBlock(receiver, 'koshien_targetCoordinate', 'value');
             converter.addField(block, 'TARGET', 'player');
@@ -249,7 +249,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'turn_over', 0, params => {
+        converter.registerOnSend(Koshien, 'turn_over', 0, params => {
             const {receiver} = params;
             return converter.changeRubyExpressionBlock(receiver, 'koshien_turnOver', 'statement');
         });
@@ -260,7 +260,7 @@ const KoshienConverter = {
             return block.value >= 0 && block.value <= 14;
         };
         const checkY = checkX;
-        converter.registerCallMethod(Koshien, 'position', 2, params => {
+        converter.registerOnSend(Koshien, 'position', 2, params => {
             const {receiver, args} = params;
 
             if (!checkX(args[0])) return null;
@@ -272,7 +272,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'position_of_x', 1, params => {
+        converter.registerOnSend(Koshien, 'position_of_x', 1, params => {
             const {receiver, args} = params;
 
             if (!checkPosition(args[0])) return null;
@@ -283,7 +283,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'position_of_y', 1, params => {
+        converter.registerOnSend(Koshien, 'position_of_y', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -294,7 +294,7 @@ const KoshienConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Koshien, 'object', 1, params => {
+        converter.registerOnSend(Koshien, 'object', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/looks.js
+++ b/src/lib/ruby-to-blocks-converter/looks.js
@@ -80,7 +80,7 @@ const validateBackdrop = function (backdropName, args) {
 const LooksConverter = {
     register: function (converter) {
         ['say', 'think'].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 1, params => {
+            converter.registerOnSend('sprite', methodName, 1, params => {
                 const {args} = params;
                 if (!converter._isNumberOrStringOrBlock(args[0])) return null;
 
@@ -99,7 +99,7 @@ const LooksConverter = {
         });
 
         ['say', 'think'].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 2, params => {
+            converter.registerOnSend('sprite', methodName, 2, params => {
                 const {args} = params;
                 if (!converter._isNumberOrStringOrBlock(args[0]) || !converter._isNumberOrBlock(args[1])) return null;
 
@@ -119,7 +119,7 @@ const LooksConverter = {
             });
         });
 
-        converter.registerCallMethod('sprite', 'switch_costume', 1, params => {
+        converter.registerOnSend('sprite', 'switch_costume', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -129,7 +129,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'switch_backdrop', 1, params => {
+        converter.registerOnSend('self', 'switch_backdrop', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -139,7 +139,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'switch_backdrop_and_wait', 1, params => {
+        converter.registerOnSend('self', 'switch_backdrop_and_wait', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -149,7 +149,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('sprite', 'size=', 1, params => {
+        converter.registerOnSend('sprite', 'size=', 1, params => {
             const {args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -158,7 +158,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'change_effect_by', 2, params => {
+        converter.registerOnSend('self', 'change_effect_by', 2, params => {
             const {args} = params;
             if (!converter._isString(args[0]) || Effects.indexOf(args[0].toString().toUpperCase()) < 0) return null;
             if (!converter._isNumberOrBlock(args[1])) return null;
@@ -169,7 +169,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'set_effect', 2, params => {
+        converter.registerOnSend('self', 'set_effect', 2, params => {
             const {args} = params;
             if (!converter._isString(args[0]) || Effects.indexOf(args[0].toString().toUpperCase()) < 0) return null;
             if (!converter._isNumberOrBlock(args[1])) return null;
@@ -180,7 +180,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('sprite', 'go_to_layer', 1, params => {
+        converter.registerOnSend('sprite', 'go_to_layer', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0]) || FrontBack.indexOf(args[0].toString()) < 0) return null;
 
@@ -189,7 +189,7 @@ const LooksConverter = {
             return block;
         });
 
-        converter.registerCallMethod('sprite', 'go_layers', 2, params => {
+        converter.registerOnSend('sprite', 'go_layers', 2, params => {
             const {args} = params;
             if (!converter._isNumberOrBlock(args[0]) || ForwardBackward.indexOf(args[1].toString()) < 0) return null;
 
@@ -200,7 +200,7 @@ const LooksConverter = {
         });
 
         ['costume_number', 'costume_name'].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 0, () => {
+            converter.registerOnSend('sprite', methodName, 0, () => {
                 const a = methodName.split('_');
                 const block = converter._createBlock(`looks_${a[0]}numbername`, 'value');
                 converter._addField(block, 'NUMBER_NAME', a[1]);
@@ -209,7 +209,7 @@ const LooksConverter = {
         });
 
         ['backdrop_number', 'backdrop_name'].forEach(methodName => {
-            converter.registerCallMethod('self', methodName, 0, params => {
+            converter.registerOnSend('self', methodName, 0, params => {
                 const {receiver} = params;
                 if (!converter._isSelf(receiver) && receiver !== Opal.nil) return null;
 
@@ -220,27 +220,27 @@ const LooksConverter = {
             });
         });
 
-        converter.registerCallMethod('sprite', 'next_costume', 0, () =>
+        converter.registerOnSend('sprite', 'next_costume', 0, () =>
             converter._createBlock('looks_nextcostume', 'statement')
         );
 
-        converter.registerCallMethod('self', 'next_backdrop', 0, () =>
+        converter.registerOnSend('self', 'next_backdrop', 0, () =>
             converter._createBlock('looks_nextbackdrop', 'statement')
         );
 
-        converter.registerCallMethod('self', 'clear_graphic_effects', 0, () =>
+        converter.registerOnSend('self', 'clear_graphic_effects', 0, () =>
             converter._createBlock('looks_cleargraphiceffects', 'statement')
         );
 
-        converter.registerCallMethod('sprite', 'show', 0, () =>
+        converter.registerOnSend('sprite', 'show', 0, () =>
             converter._createBlock('looks_show', 'statement')
         );
 
-        converter.registerCallMethod('sprite', 'hide', 0, () =>
+        converter.registerOnSend('sprite', 'hide', 0, () =>
             converter._createBlock('looks_hide', 'statement')
         );
 
-        converter.registerCallMethod('sprite', 'size', 0, () =>
+        converter.registerOnSend('sprite', 'size', 0, () =>
             converter._createBlock('looks_size', 'value')
         );
     },

--- a/src/lib/ruby-to-blocks-converter/makeymakey.js
+++ b/src/lib/ruby-to-blocks-converter/makeymakey.js
@@ -7,13 +7,13 @@ const Makey = 'makey';
  */
 const MakeyMakeyConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Makey, 0, params => {
+        converter.registerOnSend('self', Makey, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Makey, node);
         });
 
-        converter.registerCallMethodWithBlock(Makey, 'when_key_pressed', 1, 0, params => {
+        converter.registerOnSendWithBlock(Makey, 'when_key_pressed', 1, 0, params => {
             console.log(Makey, 'when_key_pressed', 1, 0, params);
             const {receiver, args, rubyBlock} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -28,7 +28,7 @@ const MakeyMakeyConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Makey, 'when_pressed_in_oder', 1, 0, params => {
+        converter.registerOnSendWithBlock(Makey, 'when_pressed_in_oder', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -43,7 +43,7 @@ const MakeyMakeyConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args, rubyBlock} = params;
             if (args.length === 2 && args[0].type === 'sym' && rubyBlock) {
                 switch (args[0].value) {

--- a/src/lib/ruby-to-blocks-converter/mesh.js
+++ b/src/lib/ruby-to-blocks-converter/mesh.js
@@ -5,13 +5,13 @@ const Mesh = 'mesh';
  */
 const MeshConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Mesh, 0, params => {
+        converter.registerOnSend('self', Mesh, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Mesh, node);
         });
 
-        converter.registerCallMethod(Mesh, 'sensor_value', 1, params => {
+        converter.registerOnSend(Mesh, 'sensor_value', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -32,13 +32,13 @@ const MicroBitConverter = {
     register: function (converter) {
         const createMicrobitBlock = node => converter.createRubyExpressionBlock(MicroBit, node);
 
-        converter.registerCallMethod('self', MicroBit, 0, params => {
+        converter.registerOnSend('self', MicroBit, 0, params => {
             const {node} = params;
 
             return createMicrobitBlock(node);
         });
 
-        converter.registerCallMethodWithBlock(MicroBit, 'when_button_pressed', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicroBit, 'when_button_pressed', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -55,7 +55,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'button_pressed?', 1, params => {
+        converter.registerOnSend(MicroBit, 'button_pressed?', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -71,7 +71,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicroBit, 'when', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicroBit, 'when', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -88,7 +88,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'display', 5, params => {
+        converter.registerOnSend(MicroBit, 'display', 5, params => {
             const {receiver, args} = params;
 
             if (!args.every(x => converter.isString(x))) return null;
@@ -104,7 +104,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'display', 1, params => {
+        converter.registerOnSend(MicroBit, 'display', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isBlock(args[0])) return null;
@@ -114,7 +114,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'display_text', 1, params => {
+        converter.registerOnSend(MicroBit, 'display_text', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -124,13 +124,13 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'clear_display', 0, params => {
+        converter.registerOnSend(MicroBit, 'clear_display', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbit_displayClear', 'statement');
         });
 
-        converter.registerCallMethodWithBlock(MicroBit, 'when_tilted', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicroBit, 'when_tilted', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -149,7 +149,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'tilted?', 1, params => {
+        converter.registerOnSend(MicroBit, 'tilted?', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -167,7 +167,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicroBit, 'tilt_angle', 1, params => {
+        converter.registerOnSend(MicroBit, 'tilt_angle', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -185,7 +185,7 @@ const MicroBitConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicroBit, 'when_pin_connected', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicroBit, 'when_pin_connected', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -198,7 +198,7 @@ const MicroBitConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethodWithBlock('self', 'when', 2, 0, params => {
+        converter.registerOnSendWithBlock('self', 'when', 2, 0, params => {
             const {args} = params;
 
             if (args[0].type !== 'sym') return null;

--- a/src/lib/ruby-to-blocks-converter/microbit_more.js
+++ b/src/lib/ruby-to-blocks-converter/microbit_more.js
@@ -102,13 +102,13 @@ const ConnectionStateMenu = [
  */
 const MicrobitMoreConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', MicrobitMore, 0, params => {
+        converter.registerOnSend('self', MicrobitMore, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(MicrobitMore, node);
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when_microbit', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_microbit', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -122,7 +122,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when_button_is', 2, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_button_is', 2, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (converter.isString(args[0])) {
@@ -149,7 +149,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'button_pressed?', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'button_pressed?', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -167,7 +167,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when_pin_is', 2, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_pin_is', 2, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (converter.isString(args[0])) {
@@ -195,7 +195,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'pin_is_touched?', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'pin_is_touched?', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -213,7 +213,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (converter.isString(args[0])) {
@@ -231,7 +231,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'display_pattern', 5, params => {
+        converter.registerOnSend(MicrobitMore, 'display_pattern', 5, params => {
             const {receiver, args} = params;
 
             if (!args.every(x => converter.isString(x))) return null;
@@ -247,7 +247,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'display_pattern', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'display_pattern', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isBlock(args[0])) return null;
@@ -257,7 +257,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'display_text_delay', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'display_text_delay', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -269,49 +269,49 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'clear_display', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'clear_display', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_displayClear', 'statement');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'light_intensity', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'light_intensity', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getLightLevel', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'temperature', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'temperature', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getTemperature', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'angle_with_north', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'angle_with_north', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getCompassHeading', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'pitch', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'pitch', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getPitch', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'roll', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'roll', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getRoll', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'sound_level', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'sound_level', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getSoundLevel', 'value');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'magnetic_force', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'magnetic_force', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -328,7 +328,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'acceleration', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'acceleration', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -345,7 +345,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'analog_value', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'analog_value', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -362,7 +362,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'set_pin_to_input_pull', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'set_pin_to_input_pull', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -388,7 +388,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'is_pin_high?', 1, params => {
+        converter.registerOnSend(MicrobitMore, 'is_pin_high?', 1, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -405,7 +405,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'set_digital', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'set_digital', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -432,7 +432,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'set_analog', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'set_analog', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -451,7 +451,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'set_servo', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'set_servo', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -471,7 +471,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'play_tone', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'play_tone', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -483,13 +483,13 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'stop_tone', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'stop_tone', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'microbitMore_stopTone', 'statement');
         });
 
-        converter.registerCallMethod(MicrobitMore, 'listen_event_on', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'listen_event_on', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -516,7 +516,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when_catch_at_pin', 2, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_catch_at_pin', 2, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (converter.isString(args[0])) {
@@ -544,7 +544,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'value_of', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'value_of', 2, params => {
             const {receiver, args} = params;
 
             if (converter.isString(args[0])) {
@@ -571,7 +571,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(MicrobitMore, 'when_data_received_from_microbit', 1, 0, params => {
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_data_received_from_microbit', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -582,7 +582,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'data', 0, params => {
+        converter.registerOnSend(MicrobitMore, 'data', 0, params => {
             const {receiver, node} = params;
 
             const block = converter.changeRubyExpressionBlock(receiver, 'ruby_expression', 'value_boolean');
@@ -591,7 +591,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMoreData, '[]', 1, params => {
+        converter.registerOnSend(MicrobitMoreData, '[]', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -601,7 +601,7 @@ const MicrobitMoreConverter = {
             return block;
         });
 
-        converter.registerCallMethod(MicrobitMore, 'send_data_to_microbit', 2, params => {
+        converter.registerOnSend(MicrobitMore, 'send_data_to_microbit', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/motion.js
+++ b/src/lib/ruby-to-blocks-converter/motion.js
@@ -13,7 +13,7 @@ const RotationStyle = [
 const MotionConverter = {
     register: function (converter) {
         // move(steps)
-        converter.registerCallMethod('sprite', 'move', 1, params => {
+        converter.registerOnSend('sprite', 'move', 1, params => {
             const {args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -24,7 +24,7 @@ const MotionConverter = {
 
         // turn_right(degrees) and turn_left(degrees)
         ['turn_right', 'turn_left'].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 1, params => {
+            converter.registerOnSend('sprite', methodName, 1, params => {
                 const {args} = params;
                 if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -36,7 +36,7 @@ const MotionConverter = {
         });
 
         // go_to(target)
-        converter.registerCallMethod('sprite', 'go_to', 1, params => {
+        converter.registerOnSend('sprite', 'go_to', 1, params => {
             const {args} = params;
             if (converter._isString(args[0])) {
                 const block = converter._createBlock('motion_goto', 'statement');
@@ -53,7 +53,7 @@ const MotionConverter = {
         });
 
         // glide(target, secs: duration)
-        converter.registerCallMethod('sprite', 'glide', 2, params => {
+        converter.registerOnSend('sprite', 'glide', 2, params => {
             const {args} = params;
             if (args.length !== 2 || !converter._isHash(args[1]) || args[1].size !== 1) return null;
 
@@ -80,7 +80,7 @@ const MotionConverter = {
         });
 
         // direction = value
-        converter.registerCallMethod('sprite', 'direction=', 1, params => {
+        converter.registerOnSend('sprite', 'direction=', 1, params => {
             const {args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -90,7 +90,7 @@ const MotionConverter = {
         });
 
         // point_towards(target)
-        converter.registerCallMethod('sprite', 'point_towards', 1, params => {
+        converter.registerOnSend('sprite', 'point_towards', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -104,11 +104,11 @@ const MotionConverter = {
         });
 
         // bounce_if_on_edge()
-        converter.registerCallMethod('sprite', 'bounce_if_on_edge', 0, () =>
+        converter.registerOnSend('sprite', 'bounce_if_on_edge', 0, () =>
             converter._createBlock('motion_ifonedgebounce', 'statement'));
 
         // rotation_style = value
-        converter.registerCallMethod('sprite', 'rotation_style=', 1, params => {
+        converter.registerOnSend('sprite', 'rotation_style=', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0]) || RotationStyle.indexOf(args[0].toString()) < 0) return null;
 
@@ -119,7 +119,7 @@ const MotionConverter = {
 
         // x = value and y = value
         ['x=', 'y='].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 1, params => {
+            converter.registerOnSend('sprite', methodName, 1, params => {
                 const {args} = params;
                 if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -132,12 +132,12 @@ const MotionConverter = {
 
         // x and y position getters
         ['x', 'y'].forEach(methodName => {
-            converter.registerCallMethod('sprite', methodName, 0, () =>
+            converter.registerOnSend('sprite', methodName, 0, () =>
                 converter._createBlock(`motion_${methodName}position`, 'value'));
         });
 
         // direction getter
-        converter.registerCallMethod('sprite', 'direction', 0, () =>
+        converter.registerOnSend('sprite', 'direction', 0, () =>
             converter._createBlock('motion_direction', 'value'));
 
         // Register onXxx handlers

--- a/src/lib/ruby-to-blocks-converter/music.js
+++ b/src/lib/ruby-to-blocks-converter/music.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
  */
 const MusicConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', 'play_drum', 1, params => {
+        converter.registerOnSend('self', 'play_drum', 1, params => {
             const {args} = params;
             if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
 
@@ -23,7 +23,7 @@ const MusicConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'rest', 1, params => {
+        converter.registerOnSend('self', 'rest', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -32,7 +32,7 @@ const MusicConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'play_note', 1, params => {
+        converter.registerOnSend('self', 'play_note', 1, params => {
             const {args} = params;
             if (!converter._isHash(args[0]) || args[0].size !== 2) return null;
 
@@ -46,7 +46,7 @@ const MusicConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'instrument=', 1, params => {
+        converter.registerOnSend('self', 'instrument=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -59,7 +59,7 @@ const MusicConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'tempo=', 1, params => {
+        converter.registerOnSend('self', 'tempo=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -68,7 +68,7 @@ const MusicConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'tempo', 0, () =>
+        converter.registerOnSend('self', 'tempo', 0, () =>
             converter.createBlock('music_getTempo', 'value')
         );
     },

--- a/src/lib/ruby-to-blocks-converter/my-blocks.js
+++ b/src/lib/ruby-to-blocks-converter/my-blocks.js
@@ -8,7 +8,7 @@ import {RubyToBlocksConverterError} from './errors';
 const MyBlocksConverter = {
     register: function (converter) {
         // Register my-block handler for procedure calls
-        converter.registerCallMyBlock('self', params => {
+        converter.registerOnSendMyBlock('self', params => {
             const {name, args, procedure} = params;
 
             if (procedure.argumentIds.length !== args.length) return null;

--- a/src/lib/ruby-to-blocks-converter/operators.js
+++ b/src/lib/ruby-to-blocks-converter/operators.js
@@ -8,14 +8,14 @@ const MathE = '::Math::E';
  */
 const OperatorsConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', 'rand', 1, params => {
+        converter.registerOnSend('self', 'rand', 1, params => {
             const {args} = params;
             if (!converter._isBlock(args[0]) || args[0].opcode !== 'ruby_range') return null;
 
             return converter._changeBlock(args[0], 'operator_random', 'value');
         });
 
-        converter.registerCallMethod(['string', 'block'], '[]', 1, params => {
+        converter.registerOnSend(['string', 'block'], '[]', 1, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -29,7 +29,7 @@ const OperatorsConverter = {
             return block;
         });
 
-        converter.registerCallMethod(['string', 'block'], 'length', 0, params => {
+        converter.registerOnSend(['string', 'block'], 'length', 0, params => {
             const {receiver} = params;
 
             const block = converter._createBlock('operator_length', 'value');
@@ -37,7 +37,7 @@ const OperatorsConverter = {
             return block;
         });
 
-        converter.registerCallMethod(['string', 'block'], 'include?', 1, params => {
+        converter.registerOnSend(['string', 'block'], 'include?', 1, params => {
             const {receiver, args} = params;
             if (!converter._isStringOrBlock(args[0])) return null;
 
@@ -48,7 +48,7 @@ const OperatorsConverter = {
         });
 
         ['+', '-', '*', '/', '%'].forEach(operator => {
-            converter.registerCallMethod(['variable', 'number', 'block'], operator, 1, params => {
+            converter.registerOnSend(['variable', 'number', 'block'], operator, 1, params => {
                 const {receiver, args} = params;
                 let rh = args[0];
                 if (_.isArray(rh)) {
@@ -78,7 +78,7 @@ const OperatorsConverter = {
             });
         });
 
-        converter.registerCallMethod(['variable', 'string', 'block'], '+', 1, params => {
+        converter.registerOnSend(['variable', 'string', 'block'], '+', 1, params => {
             const {receiver, args} = params;
             let rh = args[0];
             if (_.isArray(rh)) {
@@ -97,7 +97,7 @@ const OperatorsConverter = {
         });
 
         ['>', '<', '=='].forEach(operator => {
-            converter.registerCallMethod('any', operator, 1, params => {
+            converter.registerOnSend('any', operator, 1, params => {
                 const {receiver, args} = params;
                 let rh = args[0];
                 if (_.isArray(rh)) {
@@ -123,7 +123,7 @@ const OperatorsConverter = {
             });
         });
 
-        converter.registerCallMethod(['variable', 'boolean', 'block'], '!', 0, params => {
+        converter.registerOnSend(['variable', 'boolean', 'block'], '!', 0, params => {
             const {receiver} = params;
 
             const block = converter._createBlock('operator_not', 'value_boolean');
@@ -137,7 +137,7 @@ const OperatorsConverter = {
             return block;
         });
 
-        converter.registerCallMethod(['variable', 'number', 'block'], 'round', 0, params => {
+        converter.registerOnSend(['variable', 'number', 'block'], 'round', 0, params => {
             const {receiver} = params;
 
             const block = converter._createBlock('operator_round', 'value');
@@ -146,7 +146,7 @@ const OperatorsConverter = {
         });
 
         ['abs', 'floor', 'ceil'].forEach(methodName => {
-            converter.registerCallMethod(['variable', 'number', 'block'], methodName, 0, params => {
+            converter.registerOnSend(['variable', 'number', 'block'], methodName, 0, params => {
                 const {receiver} = params;
 
                 let operator = methodName;
@@ -161,7 +161,7 @@ const OperatorsConverter = {
         });
 
         ['sqrt', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'log', 'log10'].forEach(methodName => {
-            converter.registerCallMethod(Math, methodName, 1, params => {
+            converter.registerOnSend(Math, methodName, 1, params => {
                 const {args} = params;
                 let rh = args[0];
                 if (_.isArray(rh)) {
@@ -189,7 +189,7 @@ const OperatorsConverter = {
             });
         });
 
-        converter.registerCallMethod(MathE, '**', 1, params => {
+        converter.registerOnSend(MathE, '**', 1, params => {
             const {args} = params;
             let rh = args[0];
             if (_.isArray(rh)) {
@@ -205,7 +205,7 @@ const OperatorsConverter = {
             return block;
         });
 
-        converter.registerCallMethod('number', '**', 1, params => {
+        converter.registerOnSend('number', '**', 1, params => {
             const {receiver, args} = params;
             let rh = args[0];
             if (_.isArray(rh)) {

--- a/src/lib/ruby-to-blocks-converter/pen.js
+++ b/src/lib/ruby-to-blocks-converter/pen.js
@@ -7,51 +7,51 @@ const Pen = 'pen';
  */
 const PenConverter = {
     register: function (converter) {
-        converter.registerCallMethod('::Pen', 'clear', 0, () =>
+        converter.registerOnSend('::Pen', 'clear', 0, () =>
             converter.createBlock('pen_clear', 'statement')
         );
 
         // backward compatibility
-        converter.registerCallMethod('self', 'pen_clear', 0, () =>
+        converter.registerOnSend('self', 'pen_clear', 0, () =>
             converter.createBlock('pen_clear', 'statement')
         );
 
-        converter.registerCallMethod('sprite', Pen, 0, params => {
+        converter.registerOnSend('sprite', Pen, 0, params => {
             const {node} = params;
             return converter.createRubyExpressionBlock(Pen, node);
         });
 
-        converter.registerCallMethod(Pen, 'stamp', 0, params => {
+        converter.registerOnSend(Pen, 'stamp', 0, params => {
             const {receiver} = params;
             return converter.changeRubyExpressionBlock(receiver, 'pen_stamp', 'statement');
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_stamp', 0, () =>
+        converter.registerOnSend('sprite', 'pen_stamp', 0, () =>
             converter.createBlock('pen_stamp', 'statement')
         );
 
-        converter.registerCallMethod(Pen, 'down', 0, params => {
+        converter.registerOnSend(Pen, 'down', 0, params => {
             const {receiver} = params;
             return converter.changeRubyExpressionBlock(receiver, 'pen_penDown', 'statement');
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_down', 0, () =>
+        converter.registerOnSend('sprite', 'pen_down', 0, () =>
             converter.createBlock('pen_penDown', 'statement')
         );
 
-        converter.registerCallMethod(Pen, 'up', 0, params => {
+        converter.registerOnSend(Pen, 'up', 0, params => {
             const {receiver} = params;
             return converter.changeRubyExpressionBlock(receiver, 'pen_penUp', 'statement');
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_up', 0, () =>
+        converter.registerOnSend('sprite', 'pen_up', 0, () =>
             converter.createBlock('pen_penUp', 'statement')
         );
 
-        converter.registerCallMethod(Pen, 'color=', 1, params => {
+        converter.registerOnSend(Pen, 'color=', 1, params => {
             const {receiver, args} = params;
             if (!converter.isNumberOrBlock(args[0]) && !converter.isColorOrBlock(args[0])) return null;
 
@@ -71,7 +71,7 @@ const PenConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_color=', 1, params => {
+        converter.registerOnSend('sprite', 'pen_color=', 1, params => {
             const {args} = params;
 
             if (converter.isNumberOrBlock(args[0])) {
@@ -90,7 +90,7 @@ const PenConverter = {
             return null;
         });
 
-        converter.registerCallMethod(Pen, 'saturation=', 1, params => {
+        converter.registerOnSend(Pen, 'saturation=', 1, params => {
             const {receiver, args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -104,7 +104,7 @@ const PenConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_saturation=', 1, params => {
+        converter.registerOnSend('sprite', 'pen_saturation=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -117,7 +117,7 @@ const PenConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Pen, 'brightness=', 1, params => {
+        converter.registerOnSend(Pen, 'brightness=', 1, params => {
             const {receiver, args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -131,7 +131,7 @@ const PenConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_brightness=', 1, params => {
+        converter.registerOnSend('sprite', 'pen_brightness=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -144,7 +144,7 @@ const PenConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Pen, 'transparency=', 1, params => {
+        converter.registerOnSend(Pen, 'transparency=', 1, params => {
             const {receiver, args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -158,7 +158,7 @@ const PenConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_transparency=', 1, params => {
+        converter.registerOnSend('sprite', 'pen_transparency=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -171,7 +171,7 @@ const PenConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Pen, 'size=', 1, params => {
+        converter.registerOnSend(Pen, 'size=', 1, params => {
             const {receiver, args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -181,7 +181,7 @@ const PenConverter = {
         });
 
         // backward compatibility
-        converter.registerCallMethod('sprite', 'pen_size=', 1, params => {
+        converter.registerOnSend('sprite', 'pen_size=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 
@@ -192,7 +192,7 @@ const PenConverter = {
 
         // for +=
         ['color', 'saturation', 'brightness', 'transparency', 'size'].forEach(methodName => {
-            converter.registerCallMethod(Pen, methodName, 0, params => {
+            converter.registerOnSend(Pen, methodName, 0, params => {
                 const {receiver, node} = params;
 
                 return converter.changeRubyExpression(receiver, node);

--- a/src/lib/ruby-to-blocks-converter/sensing.js
+++ b/src/lib/ruby-to-blocks-converter/sensing.js
@@ -30,7 +30,7 @@ const SensingConverter = {
         ];
 
         simpleGetters.forEach(({method, opcode}) => {
-            converter.registerCallMethod('self', method, 0, () =>
+            converter.registerOnSend('self', method, 0, () =>
                 converter.createBlock(opcode, 'value')
             );
         });
@@ -43,7 +43,7 @@ const SensingConverter = {
         ];
 
         mouseGetters.forEach(({method, opcode, blockType}) => {
-            converter.registerCallMethod('::Mouse', method, 0, () =>
+            converter.registerOnSend('::Mouse', method, 0, () =>
                 converter.createBlock(opcode, blockType)
             );
         });
@@ -55,13 +55,13 @@ const SensingConverter = {
         ];
 
         timerMethods.forEach(({method, opcode, blockType}) => {
-            converter.registerCallMethod('::Timer', method, 0, () =>
+            converter.registerOnSend('::Timer', method, 0, () =>
                 converter.createBlock(opcode, blockType)
             );
         });
 
         // stage - returns Ruby expression
-        converter.registerCallMethod('self', Stage, 0, params => {
+        converter.registerOnSend('self', Stage, 0, params => {
             const {node} = params;
             return converter.createRubyExpressionBlock(Stage, node);
         });
@@ -72,7 +72,7 @@ const SensingConverter = {
             {method: 'volume', property: 'volume'}
         ];
         stageGetters.forEach(({method, property}) => {
-            converter.registerCallMethod(Stage, method, 0, params => {
+            converter.registerOnSend(Stage, method, 0, params => {
                 const {receiver} = params;
 
                 const block = converter.changeRubyExpressionBlock(receiver, 'sensing_of', 'value');
@@ -82,7 +82,7 @@ const SensingConverter = {
             });
         });
 
-        converter.registerCallMethod(Stage, 'variable', 1, params => {
+        converter.registerOnSend(Stage, 'variable', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -94,7 +94,7 @@ const SensingConverter = {
         });
 
         // Touching methods (sprite only)
-        converter.registerCallMethod('sprite', 'touching?', 1, params => {
+        converter.registerOnSend('sprite', 'touching?', 1, params => {
             const {args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -107,7 +107,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerCallMethod('sprite', 'touching_color?', 1, params => {
+        converter.registerOnSend('sprite', 'touching_color?', 1, params => {
             const {args} = params;
 
             if (!converter.isColorOrBlock(args[0])) return null;
@@ -117,7 +117,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerCallMethod('sprite', 'color_is_touching_color?', 2, params => {
+        converter.registerOnSend('sprite', 'color_is_touching_color?', 2, params => {
             const {args} = params;
 
             if (!converter.isColorOrBlock(args[0]) || !converter.isColorOrBlock(args[1])) return null;
@@ -129,7 +129,7 @@ const SensingConverter = {
         });
 
         // Distance method (sprite only)
-        converter.registerCallMethod('sprite', 'distance', 1, params => {
+        converter.registerOnSend('sprite', 'distance', 1, params => {
             const {args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -142,7 +142,7 @@ const SensingConverter = {
         });
 
         // Ask method (all targets)
-        converter.registerCallMethod('self', 'ask', 1, params => {
+        converter.registerOnSend('self', 'ask', 1, params => {
             const {args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -153,7 +153,7 @@ const SensingConverter = {
         });
 
         // Drag mode method (sprite only)
-        converter.registerCallMethod('sprite', 'drag_mode=', 1, params => {
+        converter.registerOnSend('sprite', 'drag_mode=', 1, params => {
             const {args} = params;
 
             const validDragMode = converter.isString(args[0]) && DragMode.indexOf(args[0].toString()) >= 0;
@@ -172,7 +172,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerCallMethod('::Keyboard', 'pressed?', 1, params => {
+        converter.registerOnSend('::Keyboard', 'pressed?', 1, params => {
             const {args} = params;
 
             const validKey = converter.isString(args[0]) && KeyOptions.indexOf(args[0].toString()) >= 0;
@@ -185,7 +185,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerCallMethod('::Time', 'now', 0, params => {
+        converter.registerOnSend('::Time', 'now', 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(TimeNow, node);
@@ -200,7 +200,7 @@ const SensingConverter = {
             {method: 'sec', currentMenu: 'SECOND'}
         ];
         timeNowMethods.forEach(({method, currentMenu}) => {
-            converter.registerCallMethod(TimeNow, method, 0, params => {
+            converter.registerOnSend(TimeNow, method, 0, params => {
                 const {receiver} = params;
 
                 const block = converter.changeRubyExpressionBlock(receiver, 'sensing_current', 'value');
@@ -210,14 +210,14 @@ const SensingConverter = {
         });
 
         // Special handling for wday - changes expression to TimeNowWday
-        converter.registerCallMethod(TimeNow, 'wday', 0, params => {
+        converter.registerOnSend(TimeNow, 'wday', 0, params => {
             const {receiver, node} = params;
 
             return converter.changeRubyExpression(receiver, node, TimeNowWday);
         });
 
         // Special handling for wday + 1 (DAYOFWEEK)
-        converter.registerCallMethod(TimeNowWday, '+', 1, params => {
+        converter.registerOnSend(TimeNowWday, '+', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isNumber(args[0]) || args[0].toString() !== '1') return null;
@@ -227,7 +227,7 @@ const SensingConverter = {
             return block;
         });
 
-        converter.registerCallMethod('self', 'sprite', 1, params => {
+        converter.registerOnSend('self', 'sprite', 1, params => {
             const {args, node} = params;
 
             if (!converter.isString(args[0])) return null;
@@ -247,7 +247,7 @@ const SensingConverter = {
         ];
 
         spriteGetters.forEach(({method, property}) => {
-            converter.registerCallMethod('sprite_call', method, 0, params => {
+            converter.registerOnSend('sprite_call', method, 0, params => {
                 const {receiver} = params;
 
                 const spriteName = converter._getSpriteCallName(receiver);
@@ -261,7 +261,7 @@ const SensingConverter = {
         });
 
         // Sprite variable method
-        converter.registerCallMethod('sprite_call', 'variable', 1, params => {
+        converter.registerOnSend('sprite_call', 'variable', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isString(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/smalrubot_s1.js
+++ b/src/lib/ruby-to-blocks-converter/smalrubot_s1.js
@@ -29,14 +29,14 @@ const SENSOR_POSITIONS = [
 const SmalrubotS1Converter = {
     register: function (converter) {
         // Create the initial Ruby expression block
-        converter.registerCallMethod('self', SmalrubotS1, 0, params => {
+        converter.registerOnSend('self', SmalrubotS1, 0, params => {
             const {node} = params;
             
             return converter.createRubyExpressionBlock(SmalrubotS1, node);
         });
 
         // Method calls on smalrubot_s1
-        converter.registerCallMethod(SmalrubotS1, 'action', 1, params => {
+        converter.registerOnSend(SmalrubotS1, 'action', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !ACTIONS.includes(args[0].toString())) return null;
@@ -48,7 +48,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'action', 2, params => {
+        converter.registerOnSend(SmalrubotS1, 'action', 2, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !ACTIONS.includes(args[0].toString()) ||
@@ -62,7 +62,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'bend_arm', 2, params => {
+        converter.registerOnSend(SmalrubotS1, 'bend_arm', 2, params => {
             const {receiver, args} = params;
             
             if (!converter.isNumberOrBlock(args[0]) || !converter.isNumberOrBlock(args[1])) return null;
@@ -75,7 +75,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'sensor_value', 1, params => {
+        converter.registerOnSend(SmalrubotS1, 'sensor_value', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !SENSOR_POSITIONS.includes(args[0].toString())) return null;
@@ -87,7 +87,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'led', 2, params => {
+        converter.registerOnSend(SmalrubotS1, 'led', 2, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !POSITIONS.includes(args[0].toString()) ||
@@ -104,7 +104,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'get_motor_speed', 1, params => {
+        converter.registerOnSend(SmalrubotS1, 'get_motor_speed', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !POSITIONS.includes(args[0].toString())) return null;
@@ -116,7 +116,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'set_motor_speed', 2, params => {
+        converter.registerOnSend(SmalrubotS1, 'set_motor_speed', 2, params => {
             const {receiver, args} = params;
             
             if (!converter.isString(args[0]) || !POSITIONS.includes(args[0].toString()) ||
@@ -130,7 +130,7 @@ const SmalrubotS1Converter = {
             return block;
         });
 
-        converter.registerCallMethod(SmalrubotS1, 'arm_calibration=', 1, params => {
+        converter.registerOnSend(SmalrubotS1, 'arm_calibration=', 1, params => {
             const {receiver, args} = params;
             
             if (!converter.isNumberOrBlock(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/sound.js
+++ b/src/lib/ruby-to-blocks-converter/sound.js
@@ -13,7 +13,7 @@ const Effect = [
 const SoundConverter = {
     register: function (converter) {
         // play_until_done method
-        converter.registerCallMethod('self', 'play_until_done', 1, params => {
+        converter.registerOnSend('self', 'play_until_done', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -36,7 +36,7 @@ const SoundConverter = {
         });
 
         // play method
-        converter.registerCallMethod('self', 'play', 1, params => {
+        converter.registerOnSend('self', 'play', 1, params => {
             const {args} = params;
             if (!converter.isStringOrBlock(args[0])) return null;
 
@@ -59,16 +59,16 @@ const SoundConverter = {
         });
 
         // stop_all_sounds method
-        converter.registerCallMethod('self', 'stop_all_sounds', 0, () =>
+        converter.registerOnSend('self', 'stop_all_sounds', 0, () =>
             converter.createBlock('sound_stopallsounds', 'statement')
         );
 
         // clear_sound_effects method
-        converter.registerCallMethod('self', 'clear_sound_effects', 0, () =>
+        converter.registerOnSend('self', 'clear_sound_effects', 0, () =>
             converter.createBlock('sound_cleareffects', 'statement')
         );
 
-        converter.registerCallMethod('self', 'volume', 0, params => {
+        converter.registerOnSend('self', 'volume', 0, params => {
             const {receiver} = params;
             if (!converter._isSelf(receiver) && receiver !== Opal.nil) return null;
 
@@ -76,7 +76,7 @@ const SoundConverter = {
         });
 
         // change_sound_effect_by method
-        converter.registerCallMethod('self', 'change_sound_effect_by', 2, params => {
+        converter.registerOnSend('self', 'change_sound_effect_by', 2, params => {
             const {args} = params;
             if (!converter.isString(args[0]) || Effect.indexOf(args[0].toString()) < 0) return null;
             if (!converter.isNumberOrBlock(args[1])) return null;
@@ -88,7 +88,7 @@ const SoundConverter = {
         });
 
         // set_sound_effect method
-        converter.registerCallMethod('self', 'set_sound_effect', 2, params => {
+        converter.registerOnSend('self', 'set_sound_effect', 2, params => {
             const {args} = params;
             if (!converter.isString(args[0]) || Effect.indexOf(args[0].toString()) < 0) return null;
             if (!converter.isNumberOrBlock(args[1])) return null;
@@ -100,7 +100,7 @@ const SoundConverter = {
         });
 
         // volume= method
-        converter.registerCallMethod('self', 'volume=', 1, params => {
+        converter.registerOnSend('self', 'volume=', 1, params => {
             const {args} = params;
             if (!converter.isNumberOrBlock(args[0])) return null;
 

--- a/src/lib/ruby-to-blocks-converter/text2speech.js
+++ b/src/lib/ruby-to-blocks-converter/text2speech.js
@@ -41,13 +41,13 @@ const LanguageMenu = [
  */
 const Text2SpeechConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Text2Speech, 0, params => {
+        converter.registerOnSend('self', Text2Speech, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Text2Speech, node);
         });
 
-        converter.registerCallMethod(Text2Speech, 'speak', 1, params => {
+        converter.registerOnSend(Text2Speech, 'speak', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -57,7 +57,7 @@ const Text2SpeechConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Text2Speech, 'voice=', 1, params => {
+        converter.registerOnSend(Text2Speech, 'voice=', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -75,7 +75,7 @@ const Text2SpeechConverter = {
             return block;
         });
 
-        converter.registerCallMethod(Text2Speech, 'language=', 1, params => {
+        converter.registerOnSend(Text2Speech, 'language=', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/translate.js
+++ b/src/lib/ruby-to-blocks-converter/translate.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 const TranslateConverter = {
     register: function (converter) {
         // translate method
-        converter.registerCallMethod('self', 'translate', 2, params => {
+        converter.registerOnSend('self', 'translate', 2, params => {
             const {args} = params;
             if (!converter._isNumberOrStringOrBlock(args[0]) || !converter._isStringOrBlock(args[1])) return null;
 
@@ -21,7 +21,7 @@ const TranslateConverter = {
         });
 
         // language method
-        converter.registerCallMethod('self', 'language', 0, () =>
+        converter.registerOnSend('self', 'language', 0, () =>
             converter._createBlock('translate_getViewerLanguage', 'value')
         );
     }

--- a/src/lib/ruby-to-blocks-converter/variables.js
+++ b/src/lib/ruby-to-blocks-converter/variables.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
  */
 const VariablesConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', 'show_variable', 1, params => {
+        converter.registerOnSend('self', 'show_variable', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -25,7 +25,7 @@ const VariablesConverter = {
             return null;
         });
 
-        converter.registerCallMethod('self', 'hide_variable', 1, params => {
+        converter.registerOnSend('self', 'hide_variable', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -45,7 +45,7 @@ const VariablesConverter = {
             return null;
         });
 
-        converter.registerCallMethod('self', 'list', 1, params => {
+        converter.registerOnSend('self', 'list', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -65,7 +65,7 @@ const VariablesConverter = {
             return null;
         });
 
-        converter.registerCallMethod('self', 'show_list', 1, params => {
+        converter.registerOnSend('self', 'show_list', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -85,7 +85,7 @@ const VariablesConverter = {
             return null;
         });
 
-        converter.registerCallMethod('self', 'hide_list', 1, params => {
+        converter.registerOnSend('self', 'hide_list', 1, params => {
             const {args} = params;
             if (!converter._isString(args[0])) return null;
 
@@ -105,7 +105,7 @@ const VariablesConverter = {
             return null;
         });
 
-        converter.registerCallMethod('variable', 'push', 1, params => {
+        converter.registerOnSend('variable', 'push', 1, params => {
             const {receiver, args} = params;
             if (!converter._isStringOrBlock(args[0]) && !converter._isNumberOrBlock(args[0])) return null;
 
@@ -116,7 +116,7 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', 'delete_at', 1, params => {
+        converter.registerOnSend('variable', 'delete_at', 1, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -125,12 +125,12 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', 'clear', 0, params => {
+        converter.registerOnSend('variable', 'clear', 0, params => {
             const {receiver} = params;
             return converter._changeBlock(receiver, 'data_deletealloflist', 'statement');
         });
 
-        converter.registerCallMethod('variable', 'insert', 2, params => {
+        converter.registerOnSend('variable', 'insert', 2, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
             if (!converter._isStringOrBlock(args[1]) && !converter._isNumberOrBlock(args[1])) return null;
@@ -143,7 +143,7 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', '[]=', 2, params => {
+        converter.registerOnSend('variable', '[]=', 2, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
             if (!converter._isStringOrBlock(args[1]) && !converter._isNumberOrBlock(args[1])) return null;
@@ -156,7 +156,7 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', '[]', 1, params => {
+        converter.registerOnSend('variable', '[]', 1, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
@@ -165,7 +165,7 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', 'index', 1, params => {
+        converter.registerOnSend('variable', 'index', 1, params => {
             const {receiver, args} = params;
             if (!converter._isStringOrBlock(args[0]) && !converter._isNumberOrBlock(args[0])) return null;
 
@@ -176,12 +176,12 @@ const VariablesConverter = {
             return block;
         });
 
-        converter.registerCallMethod('variable', 'length', 0, params => {
+        converter.registerOnSend('variable', 'length', 0, params => {
             const {receiver} = params;
             return converter._changeBlock(receiver, 'data_lengthoflist', 'value');
         });
 
-        converter.registerCallMethod('variable', 'include?', 1, params => {
+        converter.registerOnSend('variable', 'include?', 1, params => {
             const {receiver, args} = params;
             if (!converter._isStringOrBlock(args[0]) && !converter._isNumberOrBlock(args[0])) return null;
 

--- a/src/lib/ruby-to-blocks-converter/video.js
+++ b/src/lib/ruby-to-blocks-converter/video.js
@@ -24,13 +24,13 @@ const VideoStateMenu = [
  */
 const VideoConverter = {
     register: function (converter) {
-        converter.registerCallMethod('self', VideoSensing, 0, params => {
+        converter.registerOnSend('self', VideoSensing, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(VideoSensing, node);
         });
 
-        converter.registerCallMethodWithBlock(VideoSensing, 'when_video_motion_greater_than', 1, 0, params => {
+        converter.registerOnSendWithBlock(VideoSensing, 'when_video_motion_greater_than', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -41,7 +41,7 @@ const VideoConverter = {
             return block;
         });
 
-        converter.registerCallMethod(VideoSensing, 'video_on', 2, params => {
+        converter.registerOnSend(VideoSensing, 'video_on', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -69,7 +69,7 @@ const VideoConverter = {
             return block;
         });
 
-        converter.registerCallMethod(VideoSensing, 'video_turn', 1, params => {
+        converter.registerOnSend(VideoSensing, 'video_turn', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -87,7 +87,7 @@ const VideoConverter = {
             return block;
         });
 
-        converter.registerCallMethod(VideoSensing, 'video_transparency=', 1, params => {
+        converter.registerOnSend(VideoSensing, 'video_transparency=', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;

--- a/src/lib/ruby-to-blocks-converter/wedo2.js
+++ b/src/lib/ruby-to-blocks-converter/wedo2.js
@@ -36,13 +36,13 @@ const TiltDirectionMenu = TiltDirectionAnyMenu.slice(0, 4);
  */
 const Wedo2Converter = {
     register: function (converter) {
-        converter.registerCallMethod('self', Wedo2, 0, params => {
+        converter.registerOnSend('self', Wedo2, 0, params => {
             const {node} = params;
 
             return converter.createRubyExpressionBlock(Wedo2, node);
         });
 
-        converter.registerCallMethod(Wedo2, 'turn_on_for', 2, params => {
+        converter.registerOnSend(Wedo2, 'turn_on_for', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -79,10 +79,10 @@ const Wedo2Converter = {
             );
             return block;
         };
-        converter.registerCallMethod(Wedo2, 'turn_on', 1, params => createMotorToggleBlock('wedo2_motorOn', params));
-        converter.registerCallMethod(Wedo2, 'turn_off', 1, params => createMotorToggleBlock('wedo2_motorOff', params));
+        converter.registerOnSend(Wedo2, 'turn_on', 1, params => createMotorToggleBlock('wedo2_motorOn', params));
+        converter.registerOnSend(Wedo2, 'turn_off', 1, params => createMotorToggleBlock('wedo2_motorOff', params));
 
-        converter.registerCallMethod(Wedo2, 'set_power', 2, params => {
+        converter.registerOnSend(Wedo2, 'set_power', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -102,7 +102,7 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Wedo2, 'set_direction', 2, params => {
+        converter.registerOnSend(Wedo2, 'set_direction', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -130,7 +130,7 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Wedo2, 'light_color=', 1, params => {
+        converter.registerOnSend(Wedo2, 'light_color=', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isNumberOrBlock(args[0])) return null;
@@ -140,7 +140,7 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Wedo2, 'when_distance', 2, 0, params => {
+        converter.registerOnSendWithBlock(Wedo2, 'when_distance', 2, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -154,7 +154,7 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethodWithBlock(Wedo2, 'when_tilted', 1, 0, params => {
+        converter.registerOnSendWithBlock(Wedo2, 'when_tilted', 1, 0, params => {
             const {receiver, args, rubyBlock} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -173,13 +173,13 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Wedo2, 'distance', 0, params => {
+        converter.registerOnSend(Wedo2, 'distance', 0, params => {
             const {receiver} = params;
 
             return converter.changeRubyExpressionBlock(receiver, 'wedo2_getDistance', 'value');
         });
 
-        converter.registerCallMethod(Wedo2, 'tilted?', 1, params => {
+        converter.registerOnSend(Wedo2, 'tilted?', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;
@@ -197,7 +197,7 @@ const Wedo2Converter = {
             return block;
         });
 
-        converter.registerCallMethod(Wedo2, 'tilt_angle', 1, params => {
+        converter.registerOnSend(Wedo2, 'tilt_angle', 1, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;


### PR DESCRIPTION
## Summary
This PR refactors the Ruby-to-blocks converter infrastructure by renaming method registration functions for better consistency and clarity.

### Changes Made
- **Core Method Renamings:**
  - `registerCallMethod` → `registerOnSend`
  - `registerCallMethodWithBlock` → `registerOnSendWithBlock`
  - `registerCallMyBlock` → `registerOnSendMyBlock`

- **Files Updated:**
  - Updated core implementation in `index.js`
  - Refactored all core converters: Motion, Looks, Sound, Event, Control, Sensing, Operators, Variables, MyBlocks
  - Updated all extension converters: MicroBit, Video, Music, Pen, EV3, Boost, etc. (13+ extension files)
  - Total: 23 files modified with 278 insertions/deletions

### Benefits
- **Improved Naming Convention**: Method names now better reflect their purpose in handling Ruby send operations
- **Enhanced Code Maintainability**: More descriptive and intuitive method names for developers
- **Consistent API Design**: Unified naming pattern across the entire converter infrastructure
- **Zero Breaking Changes**: All existing functionality preserved

### Testing
- ✅ All converter unit tests pass
- ✅ MyBlocks converter tests specifically verified
- ✅ No functional changes, only method name updates

### Implementation Details
The refactoring systematically updated:
1. Core method definitions in the RubyToBlocksConverter class
2. All method calls across converter implementations
3. Maintained backward compatibility throughout
4. Used batch operations for extension converters to ensure consistency

This improvement addresses the need for clearer, more consistent naming in the Ruby-to-blocks converter infrastructure, making the codebase more maintainable and developer-friendly.

Closes #402

🤖 Generated with [Claude Code](https://claude.ai/code)