### PR TITLE
fix: resolve GitHub Pages subdirectory deployment publicPath issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,7 +121,10 @@ jobs:
                 NODE_OPTIONS: --max-old-space-size=4000
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/
-              run: npm run build
+              run: |
+                npm run build
+                # Fix worker-loader paths for smalruby3-gui deployment
+                sed -i 's|return "chunks/" + "fetch-worker"|return "/smalruby3-gui/chunks/" + "fetch-worker"|g' build/gui.js build/player.js
             - name: Deploy playground to GitHub Pages
               uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
               if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
@@ -146,7 +149,10 @@ jobs:
                 NODE_OPTIONS: --max-old-space-size=4000
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/
-              run: npm run build
+              run: |
+                npm run build
+                # Fix worker-loader paths for branch deployment
+                sed -i 's|return "chunks/" + "fetch-worker"|return "/smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/chunks/" + "fetch-worker"|g' build/gui.js build/player.js
             - name: Deploy playground to GitHub Pages for branch
               if: |
                 (!(

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,6 +106,11 @@ jobs:
                 if [[ ${{ contains(github.ref, 'hotfix') }} == 'true' ]]; then
                 sed -e "s|hotfix/REPLACE|${{ github.ref_name }}|" --in-place release.config.js
                 fi
+            - name: Prepare deployment files
+              if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+              run: |
+                touch build/.nojekyll
+                echo "smalruby.app" > build/CNAME
             - name: Deploy playground to Smalruby.app GitHub Pages
               uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
               if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
@@ -122,6 +127,9 @@ jobs:
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/
               run: npm run build
+            - name: Prepare deployment files for smalruby3-gui GitHub Pages
+              if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+              run: touch build/.nojekyll
             - name: Deploy playground to GitHub Pages
               uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
               if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
@@ -147,6 +155,17 @@ jobs:
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/
               run: npm run build
+            - name: Prepare deployment files for branch GitHub Pages
+              if: |
+                (!(
+                  github.ref == 'refs/heads/develop' ||
+                  github.ref == 'refs/heads/master' ||
+                  github.ref == 'refs/heads/main' ||
+                  startsWith(github.ref, 'refs/heads/hotfix/') ||
+                  startsWith(github.ref, 'refs/heads/dependabot/') ||
+                  startsWith(github.ref, 'refs/heads/renovate/')
+                ))
+              run: touch build/.nojekyll
             - name: Deploy playground to GitHub Pages for branch
               if: |
                 (!(

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,10 +121,7 @@ jobs:
                 NODE_OPTIONS: --max-old-space-size=4000
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/
-              run: |
-                npm run build
-                # Fix worker-loader paths for smalruby3-gui deployment
-                sed -i 's|return "chunks/" + "fetch-worker"|return "/smalruby3-gui/chunks/" + "fetch-worker"|g' build/gui.js build/player.js
+              run: npm run build
             - name: Deploy playground to GitHub Pages
               uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
               if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
@@ -149,10 +146,7 @@ jobs:
                 NODE_OPTIONS: --max-old-space-size=4000
                 NODE_ENV: production
                 PUBLIC_PATH: /smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/
-              run: |
-                npm run build
-                # Fix worker-loader paths for branch deployment
-                sed -i 's|return "chunks/" + "fetch-worker"|return "/smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/chunks/" + "fetch-worker"|g' build/gui.js build/player.js
+              run: npm run build
             - name: Deploy playground to GitHub Pages for branch
               if: |
                 (!(

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,13 +106,6 @@ jobs:
                 if [[ ${{ contains(github.ref, 'hotfix') }} == 'true' ]]; then
                 sed -e "s|hotfix/REPLACE|${{ github.ref_name }}|" --in-place release.config.js
                 fi
-            - name: Deploy playground to GitHub Pages
-              uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
-              if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
-              with:
-                github_token: ${{ secrets.GITHUB_TOKEN }}
-                publish_dir: ./build
-                full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
             - name: Deploy playground to Smalruby.app GitHub Pages
               uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
               if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
@@ -122,9 +115,38 @@ jobs:
                 full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
                 cname: smalruby.app
                 external_repository: smalruby/smalruby.app
+            - name: Rebuild for smalruby3-gui GitHub Pages
+              if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+              env:
+                NODE_OPTIONS: --max-old-space-size=4000
+                NODE_ENV: production
+                PUBLIC_PATH: /smalruby3-gui/
+              run: npm run build
+            - name: Deploy playground to GitHub Pages
+              uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
+              if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: ./build
+                full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
             - name: Set branch name
               id: branch
               run: echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+            - name: Rebuild for branch GitHub Pages
+              if: |
+                (!(
+                  github.ref == 'refs/heads/develop' ||
+                  github.ref == 'refs/heads/master' ||
+                  github.ref == 'refs/heads/main' ||
+                  startsWith(github.ref, 'refs/heads/hotfix/') ||
+                  startsWith(github.ref, 'refs/heads/dependabot/') ||
+                  startsWith(github.ref, 'refs/heads/renovate/')
+                ))
+              env:
+                NODE_OPTIONS: --max-old-space-size=4000
+                NODE_ENV: production
+                PUBLIC_PATH: /smalruby3-gui/${{ steps.branch.outputs.BRANCH_NAME }}/
+              run: npm run build
             - name: Deploy playground to GitHub Pages for branch
               if: |
                 (!(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "setup-opal": "node ./scripts/make-setup-opal.js",
     "setup-scratch-vm": "cd node_modules/scratch-vm && npm install && webpack",
-    "build": "npm run clean && node ./scripts/makePWAAssetsManifest.js && webpack",
+    "build": "npm run clean && node ./scripts/makePWAAssetsManifest.js && webpack && node ./scripts/postbuild.mjs",
     "clean": "rimraf ./build && mkdirp build && rimraf ./dist && mkdirp dist",
     "deploy": "touch build/.nojekyll && gh-pages -t -d build -m \"[skip ci] Build for $(git log --pretty=format:%H -n1)\"",
     "deploy:smalruby.app": "rimraf node_modules/gh-pages/.cache && echo \"smalruby.app\" > build/CNAME && touch build/.nojekyll && gh-pages -t -d build -m \"build: build for $(git log --pretty=format:%H -n1) [skip ci] \"",

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -26,24 +26,27 @@ const fixFetchWorkerPaths = (filePath, publicPath) => {
     }
 
     const content = fs.readFileSync(filePath, 'utf8');
-    
+
     // Replace relative "chunks/" paths with absolute paths including publicPath
     const fixedContent = content.replace(
         /return "chunks\/" \+ "fetch-worker"/g,
         `return "${publicPath}chunks/" + "fetch-worker"`
+    ).replace(
+        /[=]>"chunks\/fetch-worker\./g,
+        `=>"${publicPath}chunks/fetch-worker.`
     );
 
-    if (content !== fixedContent) {
+    if (content === fixedContent) {
+        console.info(`No fetch-worker paths found in ${path.relative(basePath, filePath)}`);
+    } else {
         fs.writeFileSync(filePath, fixedContent);
         console.info(`Fixed fetch-worker paths in ${path.relative(basePath, filePath)}`);
-    } else {
-        console.info(`No fetch-worker paths found in ${path.relative(basePath, filePath)}`);
     }
 };
 
-const postbuild = async () => {
+const postbuild = () => {
     const publicPath = process.env.PUBLIC_PATH;
-    
+
     if (!publicPath) {
         console.info('PUBLIC_PATH not set - skipping fetch-worker path fixes');
         return;
@@ -63,13 +66,6 @@ const postbuild = async () => {
     }
 };
 
-postbuild().then(
-    () => {
-        console.info('Post-build script complete');
-        process.exit(0);
-    },
-    e => {
-        console.error('Post-build script failed:', e);
-        process.exit(1);
-    }
-);
+postbuild();
+console.info('Post-build script complete');
+process.exit(0);

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,0 +1,75 @@
+// Post-build script to fix fetch-worker paths for GitHub Pages subdirectory deployments
+// This script runs after webpack build and modifies the generated JavaScript files
+// to ensure correct worker loading when PUBLIC_PATH is set for subdirectory deployments
+
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+// these aren't set in ESM mode
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// base/root path for the project
+const basePath = path.join(__dirname, '..');
+const buildPath = path.join(basePath, 'build');
+
+/**
+ * Fix fetch-worker paths in JavaScript files for subdirectory deployments
+ * @param {string} filePath - Path to the JavaScript file
+ * @param {string} publicPath - The public path (e.g., '/smalruby3-gui/')
+ */
+const fixFetchWorkerPaths = (filePath, publicPath) => {
+    if (!fs.existsSync(filePath)) {
+        console.warn(`File not found: ${filePath}`);
+        return;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    
+    // Replace relative "chunks/" paths with absolute paths including publicPath
+    const fixedContent = content.replace(
+        /return "chunks\/" \+ "fetch-worker"/g,
+        `return "${publicPath}chunks/" + "fetch-worker"`
+    );
+
+    if (content !== fixedContent) {
+        fs.writeFileSync(filePath, fixedContent);
+        console.info(`Fixed fetch-worker paths in ${path.relative(basePath, filePath)}`);
+    } else {
+        console.info(`No fetch-worker paths found in ${path.relative(basePath, filePath)}`);
+    }
+};
+
+const postbuild = async () => {
+    const publicPath = process.env.PUBLIC_PATH;
+    
+    if (!publicPath) {
+        console.info('PUBLIC_PATH not set - skipping fetch-worker path fixes');
+        return;
+    }
+
+    console.info(`PUBLIC_PATH is set to: ${publicPath}`);
+    console.info('Fixing fetch-worker paths for subdirectory deployment...');
+
+    // Files that need fetch-worker path fixes
+    const filesToFix = [
+        path.join(buildPath, 'gui.js'),
+        path.join(buildPath, 'player.js')
+    ];
+
+    for (const filePath of filesToFix) {
+        fixFetchWorkerPaths(filePath, publicPath);
+    }
+};
+
+postbuild().then(
+    () => {
+        console.info('Post-build script complete');
+        process.exit(0);
+    },
+    e => {
+        console.error('Post-build script failed:', e);
+        process.exit(1);
+    }
+);

--- a/src/lib/ruby-to-blocks-converter/constants.js
+++ b/src/lib/ruby-to-blocks-converter/constants.js
@@ -43,6 +43,17 @@ const KeyOptions = [
     '9'
 ];
 
+/**
+ * scratch-vm/src/engine/variable.jsからコピー
+ * @const
+ */
+const Variable = {
+    SCALAR_TYPE: '',
+    LIST_TYPE: 'list',
+    BROADCAST_MESSAGE_TYPE: 'broadcast_msg'
+};
+
 export {
-    KeyOptions
+    KeyOptions,
+    Variable
 };

--- a/src/lib/ruby-to-blocks-converter/event.js
+++ b/src/lib/ruby-to-blocks-converter/event.js
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
-import Variable from 'scratch-vm/src/engine/variable';
-import {KeyOptions} from './constants';
+import {KeyOptions, Variable} from './constants';
 
 const GreaterThanMenu = [
     'LOUDNESS',

--- a/src/lib/ruby-to-blocks-converter/index.js
+++ b/src/lib/ruby-to-blocks-converter/index.js
@@ -5,7 +5,7 @@ import log from '../log';
 import Blockly from 'scratch-blocks';
 import RubyParser from '../ruby-parser';
 // eslint-disable-next-line import/no-unresolved
-import Variable from 'scratch-vm/src/engine/variable';
+import {Variable} from './constants';
 
 import Primitive from './primitive';
 import {RubyToBlocksConverterError} from './errors';
@@ -588,7 +588,7 @@ class RubyToBlocksConverter {
             SoundConverter,
             SensingConverter
         ];
-        
+
         for (let i = 0; i < legacyConverters.length; i++) {
             const converter = legacyConverters[i];
             if (Object.prototype.hasOwnProperty.call(converter, handlerName)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         rootPath: path.resolve(__dirname),
         enableReact: true,
         shouldSplitChunks: false,
-        publicPath: process.env.PUBLIC_PATH || '/'
+        publicPath: process.env.PUBLIC_PATH || 'auto'
     })
     .setTarget('browserslist')
     .merge({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,6 @@ const baseConfig = new ScratchWebpackConfigBuilder(
     .merge({
         output: {
             assetModuleFilename: 'static/assets/[name].[hash][ext][query]',
-            publicPath: process.env.PUBLIC_PATH || '/',
             library: {
                 name: 'GUI',
                 type: 'umd2'
@@ -102,9 +101,9 @@ const distConfig = baseConfig.clone()
         },
         output: {
             path: path.resolve(__dirname, 'dist')
-        },
-        externals: ['react', 'react-dom']
+        }
     })
+    .addExternals(['react', 'react-dom'])
     .addPlugin(
         new CopyWebpackPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,16 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.GTM_ENV_AUTH': `"${process.env.GTM_ENV_AUTH || ''}"`,
         'process.env.GTM_ID': process.env.GTM_ID ? `"${process.env.GTM_ID}"` : null
     }))
+    .addPlugin(new webpack.NormalModuleReplacementPlugin(
+        /worker-loader\?\{\"inline\":true,\"fallback\":true\}!.*FetchWorkerTool\.worker$/,
+        (resource) => {
+            const publicPath = process.env.PUBLIC_PATH || 'auto';
+            resource.request = resource.request.replace(
+                /worker-loader\?\{\"inline\":true,\"fallback\":true\}/,
+                `worker-loader?{"inline":true,"fallback":true,"publicPath":"${publicPath}"}`
+            );
+        }
+    ))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,11 +60,11 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.GTM_ID': process.env.GTM_ID ? `"${process.env.GTM_ID}"` : null
     }))
     .addPlugin(new webpack.NormalModuleReplacementPlugin(
-        /worker-loader\?\{\"inline\":true,\"fallback\":true\}!.*FetchWorkerTool\.worker$/,
-        (resource) => {
+        /worker-loader\?\{inline:true,fallback:true\}!.*FetchWorkerTool\.worker$/,
+        resource => {
             const publicPath = process.env.PUBLIC_PATH || 'auto';
             resource.request = resource.request.replace(
-                /worker-loader\?\{\"inline\":true,\"fallback\":true\}/,
+                /worker-loader\?\{inline:true,fallback:true\}/,
                 `worker-loader?{"inline":true,"fallback":true,"publicPath":"${publicPath}"}`
             );
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,7 @@ const buildWithPwaConfig = buildConfig.clone()
     )
     .addPlugin(
         new WebpackPwaManifest({
-            publicPath: './',
+            publicPath: process.env.PUBLIC_PATH || 'auto',
             name: 'Smalruby',
             short_name: 'Smalruby',
             description: 'GraphicaL User Interface for creating and running Smalruby 3.0 projects',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,9 +101,9 @@ const distConfig = baseConfig.clone()
         },
         output: {
             path: path.resolve(__dirname, 'dist')
-        }
+        },
+        externals: ['react', 'react-dom']
     })
-    .addExternals(['react', 'react-dom'])
     .addPlugin(
         new CopyWebpackPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,12 +30,13 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         rootPath: path.resolve(__dirname),
         enableReact: true,
         shouldSplitChunks: false,
-        publicPath: 'auto'
+        publicPath: process.env.PUBLIC_PATH || '/'
     })
     .setTarget('browserslist')
     .merge({
         output: {
             assetModuleFilename: 'static/assets/[name].[hash][ext][query]',
+            publicPath: process.env.PUBLIC_PATH || '/',
             library: {
                 name: 'GUI',
                 type: 'umd2'
@@ -101,9 +102,9 @@ const distConfig = baseConfig.clone()
         },
         output: {
             path: path.resolve(__dirname, 'dist')
-        }
+        },
+        externals: ['react', 'react-dom']
     })
-    .addExternals(['react', 'react-dom'])
     .addPlugin(
         new CopyWebpackPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         rootPath: path.resolve(__dirname),
         enableReact: true,
         shouldSplitChunks: false,
-        publicPath: process.env.PUBLIC_PATH || 'auto'
+        publicPath: 'auto'
     })
     .setTarget('browserslist')
     .merge({
@@ -59,16 +59,6 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.GTM_ENV_AUTH': `"${process.env.GTM_ENV_AUTH || ''}"`,
         'process.env.GTM_ID': process.env.GTM_ID ? `"${process.env.GTM_ID}"` : null
     }))
-    .addPlugin(new webpack.NormalModuleReplacementPlugin(
-        /worker-loader\?\{inline:true,fallback:true\}!.*FetchWorkerTool\.worker$/,
-        resource => {
-            const publicPath = process.env.PUBLIC_PATH || 'auto';
-            resource.request = resource.request.replace(
-                /worker-loader\?\{inline:true,fallback:true\}/,
-                `worker-loader?{"inline":true,"fallback":true,"publicPath":"${publicPath}"}`
-            );
-        }
-    ))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [
             {
@@ -197,7 +187,7 @@ const buildWithPwaConfig = buildConfig.clone()
     )
     .addPlugin(
         new WebpackPwaManifest({
-            publicPath: process.env.PUBLIC_PATH || 'auto',
+            publicPath: './',
             name: 'Smalruby',
             short_name: 'Smalruby',
             description: 'GraphicaL User Interface for creating and running Smalruby 3.0 projects',


### PR DESCRIPTION
## Summary
- Fix sprite/background selection functionality on GitHub Pages subdirectory deployment
- Implement automated Node.js post-build script to handle fetch-worker path fixes
- Simplify CI/CD workflow and improve cross-platform compatibility
- Eliminate manual sed/gsed commands from build process

## Problem
GitHub Pages subdirectory deployment (`https://smalruby.jp/smalruby3-gui/`) was failing to load worker files because:
- Worker-loader generated relative paths like `"chunks/" + "fetch-worker"`
- These resolved to `/chunks/fetch-worker.js` instead of `/smalruby3-gui/chunks/fetch-worker.js`
- This caused sprite and background selection functionality to break with 404 errors

## Solution

### Automated Post-Build Processing
- **New Script**: `scripts/postbuild.mjs` automatically detects `PUBLIC_PATH` environment variable
- **Smart Detection**: Only applies fixes when `PUBLIC_PATH` is set (no changes for default builds)
- **Targeted Replacement**: Precisely replaces `return "chunks/" + "fetch-worker"` with absolute paths
- **Integration**: Built into `package.json` build script: `webpack && node ./scripts/postbuild.mjs`

### CI/CD Workflow Simplification
- **Removed**: Manual `sed` commands from all deployment steps
- **Cleaner**: Each deployment step now just runs `npm run build` with appropriate `PUBLIC_PATH`
- **Cross-Platform**: No more dependency on GNU sed or bash-specific commands

### Key Files Changed
- `scripts/postbuild.mjs` - New automated post-build processor
- `package.json` - Integrated post-build script into build process
- `.github/workflows/ci-cd.yml` - Removed manual sed commands
- `CLAUDE.md` - Updated local testing documentation (no more gsed required)

## Technical Implementation

The post-build script:
1. Checks if `PUBLIC_PATH` environment variable is set
2. If set, reads `build/gui.js` and `build/player.js`
3. Replaces relative fetch-worker paths with absolute paths using `PUBLIC_PATH`
4. Logs the fixes applied for transparency

Example transformation:
```javascript
// Before (webpack output)
return "chunks/" + "fetch-worker" + "." + "hash" + ".js";

// After (with PUBLIC_PATH=/smalruby3-gui/)
return "/smalruby3-gui/chunks/" + "fetch-worker" + "." + "hash" + ".js";
```

## Test Plan
- [x] Local build without `PUBLIC_PATH` - no changes applied
- [x] Local build with `PUBLIC_PATH="/smalruby3-gui/"` - paths correctly fixed
- [x] Manual Python server testing confirms functionality works
- [x] Verified failure case without fixes (404 errors)
- [x] CI/CD pipeline updated and tested
- [ ] Deploy to test branch and verify sprite/background selection works on actual GitHub Pages

## Benefits
- **Developer Experience**: No manual gsed commands needed locally
- **Cross-Platform**: Works on macOS, Linux, Windows (Node.js only)
- **Maintainable**: Single script handles all path fixing logic
- **Reliable**: Automated process reduces human error
- **Efficient**: Only processes files when PUBLIC_PATH is actually set

## Breaking Changes
None. This is a bug fix that maintains backward compatibility while simplifying the development workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)