### PR TITLE
fix: escape spaces in variable/list names for AI save

### DIFF
--- a/src/lib/ruby-generator/index.js
+++ b/src/lib/ruby-generator/index.js
@@ -295,7 +295,7 @@ RubyGenerator.spriteNew = function (renderedTarget) {
     if (variables.length > 0) {
         const s = variables.map(i => {
             const h = {
-                name: this.quote_(i.name)
+                name: this.quote_(this.escapeVariableName(i.name))
             };
             if (i.value !== 0) {
                 h.value = this.scalarToCode(i.value);
@@ -307,7 +307,7 @@ RubyGenerator.spriteNew = function (renderedTarget) {
     if (lists.length > 0) {
         const s = lists.map(i => {
             const h = {
-                name: this.quote_(i.name)
+                name: this.quote_(this.escapeVariableName(i.name))
             };
             if (i.value.length > 0) {
                 h.value = this.listToCode(i.value);

--- a/test/unit/lib/ruby-generator.test.jsx
+++ b/test/unit/lib/ruby-generator.test.jsx
@@ -355,5 +355,70 @@ describe('RubyGenerator', () => {
           ])`;
             expect(RubyGenerator.spriteNew(renderedTarget)).toEqual(expected);
         });
+
+        test('escape variable and list names with spaces', () => {
+            Object.assign(renderedTarget, {
+                variables: {
+                    id1: {
+                        name: 'my variable',
+                        type: SCALAR_TYPE,
+                        value: 10
+                    },
+                    id2: {
+                        name: 'my list',
+                        type: LIST_TYPE,
+                        value: [1, 2, 3]
+                    },
+                    id3: {
+                        name: 'variable with spaces',
+                        type: SCALAR_TYPE,
+                        value: 'test'
+                    }
+                }
+            });
+            const expected = `Sprite.new(${RubyGenerator.quote_(spriteName)},
+           x: ${renderedTarget.x},
+           y: ${renderedTarget.y},
+           direction: ${renderedTarget.direction},
+           visible: ${!!renderedTarget.visible},
+           size: ${renderedTarget.size},
+           current_costume: ${renderedTarget.currentCostume - 1},
+           costumes: [
+             {
+               asset_id: "01ae57fd339529445cb890978ef8a054",
+               name: "Costume1",
+               bitmap_resolution: 2,
+               data_format: "svg",
+               rotation_center_x: 47,
+               rotation_center_y: 55
+             },
+             {
+               asset_id: "3b6274510488d5b26447c1c266475801",
+               name: "Costume2",
+               bitmap_resolution: 1,
+               data_format: "png",
+               rotation_center_x: 65,
+               rotation_center_y: 61
+             }
+           ],
+           rotation_style: "left-right",
+           variables: [
+             {
+               name: "my_variable",
+               value: 10
+             },
+             {
+               name: "variable_with_spaces",
+               value: "test"
+             }
+           ],
+           lists: [
+             {
+               name: "my_list",
+               value: [1, 2, 3]
+             }
+           ])`;
+            expect(RubyGenerator.spriteNew(renderedTarget)).toEqual(expected);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fix bug where variable and list names containing spaces were not properly escaped when saving AI programs in Koshien extension's "AIを保存" feature.

## Problem

When using the Koshien extension's "AIを保存" (Save AI) feature, variable and list names containing spaces were output as-is in the generated Ruby code, creating invalid Ruby identifiers.

**Example of problematic output:**
```ruby
Sprite.new("Sprite1",
  variables: [
    {
      name: "my variable"  # Invalid - contains space
    }
  ]
)
```

## Solution

Modified the `spriteNew()` function in `src/lib/ruby-generator/index.js` to use `escapeVariableName()` when generating variable and list names. This ensures spaces and other special characters are replaced with underscores.

**Example of fixed output:**
```ruby
Sprite.new("Sprite1",
  variables: [
    {
      name: "my_variable"  # Valid - spaces replaced with underscores
    }
  ]
)
```

## Implementation Details

### Modified Files
- **src/lib/ruby-generator/index.js**
  - Line 298: Added `escapeVariableName()` call for variable names
  - Line 310: Added `escapeVariableName()` call for list names

### Test Coverage
- **test/unit/lib/ruby-generator.test.jsx**
  - Added new test case: "escape variable and list names with spaces"
  - Tests variable names: `'my variable'` → `"my_variable"`
  - Tests list names: `'my list'` → `"my_list"`

## Testing

### TDD Approach
1. ✅ Added failing test (RED)
2. ✅ Implemented fix (GREEN)
3. ✅ Verified lint passes

### Test Results
```
PASS test/unit/lib/ruby-generator.test.jsx
  ✓ escape variable and list names with spaces
```

All 14 tests pass.

## Related Issue

Fixes #438

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)