### PR TITLE
feat: add entry form link to Smalruby Koshien menu

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -215,7 +215,8 @@ class MenuBar extends React.Component {
             'restoreOptionMessage',
             'handleClickLoadFromUrl',
             'handleSaveDirectlyToGoogleDrive',
-            'handleExtensionAdded'
+            'handleExtensionAdded',
+            'handleClickKoshienEntryForm'
         ]);
     }
     componentDidMount () {
@@ -340,6 +341,10 @@ class MenuBar extends React.Component {
         setTimeout(() => {
             this.props.onClearAiSaveStatus();
         }, 3000);
+    }
+    handleClickKoshienEntryForm () {
+        this.props.onRequestCloseKoshien();
+        window.open('https://smalruby-koshien.netlab.jp/entry-form.html', '_blank');
     }
     getSaveAIAsHandler (downloadProjectCallback) {
         return () => {
@@ -911,6 +916,17 @@ class MenuBar extends React.Component {
                                                 defaultMessage="Test AI"
                                                 description="Menu bar item for testing AI"
                                                 id="gui.menuBar.testAI"
+                                            />
+                                        </MenuItem>
+                                    </MenuSection>
+                                    <MenuSection>
+                                        <MenuItem
+                                            onClick={this.handleClickKoshienEntryForm}
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Entry Form"
+                                                description="Menu bar item for Smalruby Koshien entry form"
+                                                id="gui.menuBar.koshienEntryForm"
                                             />
                                         </MenuItem>
                                     </MenuSection>

--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -344,7 +344,7 @@ class MenuBar extends React.Component {
     }
     handleClickKoshienEntryForm () {
         this.props.onRequestCloseKoshien();
-        window.open('https://smalruby-koshien.netlab.jp/entry-form.html', '_blank');
+        window.open('https://smalruby-koshien.netlab.jp/entry-form.html', '_blank', 'noopener,noreferrer');
     }
     getSaveAIAsHandler (downloadProjectCallback) {
         return () => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -62,6 +62,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.alwaysVisibleTitle': 'Always Visible:',
     'gui.smalruby3.blockDisplayModal.blocksSubtitle': ' Blocks',
     'gui.menuBar.blockDisplay': 'Block Display...',
+    'gui.menuBar.koshienEntryForm': 'Entry Form',
 
     // Block Display Modal - Block Messages
     // Motion blocks

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -76,6 +76,7 @@ export default {
     'gui.smalruby3.blockDisplayModal.copyUrl': 'URLのこぴー',
     'gui.smalruby3.blockDisplayModal.saveToFile': 'ふぁいるにせってい',
     'gui.menuBar.blockDisplay': 'ブロックひょうじ...',
+    'gui.menuBar.koshienEntryForm': 'さんかもうしこみ',
 
     // Block Display Modal - Block Messages (Hiragana)
     // Motion blocks

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -13,6 +13,7 @@ export default {
     'gui.menuBar.saveAI': 'AIを保存',
     'gui.menuBar.saveAIAs': 'AIに名前をつけて保存...',
     'gui.menuBar.testAI': 'AIを試す',
+    'gui.menuBar.koshienEntryForm': '参加申し込み',
     'gui.menuBar.aiSaving': 'ルビーを保存中...',
     'gui.menuBar.aiSaved': 'ルビーが保存されました。',
     'gui.koshienTestModal.title': 'スモウルビー甲子園のAIを試す',


### PR DESCRIPTION
Added a new menu item "Entry Form" to the Smalruby Koshien menu that links to https://smalruby-koshien.netlab.jp/entry-form.html.

Fixes #456