### PR TITLE
fix: clear AI save status when file save is cancelled or fails

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -212,6 +212,7 @@ class MenuBar extends React.Component {
             'getSaveAIAsHandler',
             'handleAISaveFinished',
             'handleAISaveAsFinished',
+            'handleAISaveError',
             'restoreOptionMessage',
             'handleClickLoadFromUrl',
             'handleSaveDirectlyToGoogleDrive',
@@ -363,6 +364,10 @@ class MenuBar extends React.Component {
         setTimeout(() => {
             this.props.onClearAiSaveStatus();
         }, 3000);
+    }
+    handleAISaveError () {
+        // Clear AI save status
+        this.props.onClearAiSaveStatus();
     }
     handleClickLoadFromUrl () {
         if (this.props.onStartSelectingUrlLoad) {
@@ -876,7 +881,10 @@ class MenuBar extends React.Component {
                                     onRequestClose={this.props.onRequestCloseKoshien}
                                 >
                                     <MenuSection>
-                                        <RubyDownloader onSaveFinished={this.handleAISaveFinished}>
+                                        <RubyDownloader
+                                            onSaveError={this.handleAISaveError}
+                                            onSaveFinished={this.handleAISaveFinished}
+                                        >
                                             {(className, downloadProjectCallback) => (
                                                 <MenuItem
                                                     className={className}
@@ -892,6 +900,7 @@ class MenuBar extends React.Component {
                                         </RubyDownloader>
                                         <RubyDownloader
                                             forceFilePicker
+                                            onSaveError={this.handleAISaveError}
                                             onSaveFinished={this.handleAISaveAsFinished}
                                         >
                                             {(className, downloadProjectCallback) => (

--- a/src/containers/ruby-downloader.jsx
+++ b/src/containers/ruby-downloader.jsx
@@ -77,6 +77,9 @@ class RubyDownloader extends React.Component {
             if (err.name !== 'AbortError') {
                 console.error('Error saving file:', err);
             }
+            if (this.props.onSaveError) {
+                this.props.onSaveError(err);
+            }
         }
     }
     downloadProject () {
@@ -132,6 +135,7 @@ RubyDownloader.propTypes = {
     forceFilePicker: PropTypes.bool,
     koshienFileHandle: PropTypes.object,
     onSaveFinished: PropTypes.func,
+    onSaveError: PropTypes.func,
     onSetKoshienFileHandle: PropTypes.func,
     projectFilename: PropTypes.string,
     rubyCode: rubyCodeShape,

--- a/src/containers/ruby-tab.jsx
+++ b/src/containers/ruby-tab.jsx
@@ -36,7 +36,8 @@ class RubyTab extends React.Component {
             'setAceEditorRef',
             'getSaveToComputerHandler',
             'getSaveAIHandler',
-            'handleAISaveFinished'
+            'handleAISaveFinished',
+            'handleAISaveError'
         ]);
         this.mainTooltipId = 'ruby-downloader-tooltip';
     }
@@ -120,6 +121,11 @@ class RubyTab extends React.Component {
         }, 3000);
     }
 
+    handleAISaveError () {
+        // Clear AI save status
+        this.props.onClearAiSaveStatus();
+    }
+
     render () {
         const {
             onChange,
@@ -164,7 +170,10 @@ class RubyTab extends React.Component {
                     onChange={onChange}
                 />
                 <div className={styles.wrapper}>
-                    <RubyDownloader onSaveFinished={this.handleAISaveFinished}>
+                    <RubyDownloader
+                        onSaveError={this.handleAISaveError}
+                        onSaveFinished={this.handleAISaveFinished}
+                    >
                         {(_, downloadProjectCallback) => (
                             <button
                                 className={styles.button}

--- a/test/unit/containers/ruby-downloader.test.jsx
+++ b/test/unit/containers/ruby-downloader.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {Provider} from 'react-redux';
+import configureStore from 'redux-mock-store';
+import RubyDownloader from '../../../src/containers/ruby-downloader';
+import VM from 'scratch-vm';
+
+describe('RubyDownloader Container', () => {
+    const mockStore = configureStore();
+    let store;
+    let vm;
+
+    beforeEach(() => {
+        vm = new VM();
+        vm.runtime.targets = [
+            {id: 'stage', blocks: {}, isStage: true}
+        ];
+        store = mockStore({
+            scratchGui: {
+                koshienFile: {
+                    fileHandle: null
+                },
+                projectTitle: 'project',
+                targets: {
+                    sprites: {},
+                    stage: {id: 'stage', blocks: {}}
+                },
+                vm: vm,
+                rubyCode: {
+                    modified: false,
+                    code: '',
+                    target: {id: 'target', blocks: {}}
+                }
+            }
+        });
+        // Mock showSaveFilePicker
+        window.showSaveFilePicker = jest.fn();
+    });
+
+    test('calls onSaveError when showSaveFilePicker rejects', (done) => {
+        const error = {name: 'AbortError', message: 'Abort'};
+        window.showSaveFilePicker.mockImplementation(() => Promise.reject(error));
+
+        const onSaveError = (err) => {
+            try {
+                expect(err).toBe(error);
+                done();
+            } catch (e) {
+                done.fail(e);
+            }
+        };
+
+        const wrapper = mount(
+            <Provider store={store}>
+                <RubyDownloader onSaveError={onSaveError}>
+                    {(className, downloadProject) => (
+                        <button id="download-button" onClick={downloadProject}>Download</button>
+                    )}
+                </RubyDownloader>
+            </Provider>
+        );
+
+        // Mock saveRuby to avoid complex VM dependencies
+        wrapper.find('RubyDownloader').instance().saveRuby = jest.fn(() => new Blob(['test'], {type: 'text/plain'}));
+
+        wrapper.find('#download-button').simulate('click');
+    });
+});


### PR DESCRIPTION
## Summary
This PR fixes an issue where the "ルビーを保存中..." (Saving Ruby...) progress indicator remained visible indefinitely if the user cancelled the file save dialog in the Smalruby Koshien menu.

## Implementation Details
- **RubyDownloader**: Added an `onSaveError` prop that is called when `window.showSaveFilePicker` rejects (e.g., `AbortError` on cancellation).
- **MenuBar & RubyTab**: Implemented `handleAISaveError` to clear the AI save status and passed it to `RubyDownloader`.

## Test Coverage
- Added unit test `test/unit/containers/ruby-downloader.test.jsx` to verify `onSaveError` is called when the save dialog is cancelled.
- Verified all unit tests pass with `npm run test:unit`.
- Verified code style with `npm run test:lint`.

Fixes #440