### PR TITLE
fix: set Google Picker display mode to list view

### DIFF
--- a/src/lib/google-drive-api.js
+++ b/src/lib/google-drive-api.js
@@ -130,6 +130,7 @@ class GoogleDriveAPI {
             // Create DocsView with .sb3 query filter, starting from root
             const docsView = new window.google.picker.DocsView()
                 .setIncludeFolders(true)
+                .setMode(window.google.picker.DocsViewMode.LIST)
                 .setQuery('.sb3')
                 .setParent('root'); // Start from root folder for hierarchical navigation
 


### PR DESCRIPTION
## Summary
This PR changes the Google Picker's display mode to list view when loading projects from Google Drive.

## Implementation Details
In , the  configuration in  was updated to include .

## Benefits
- File details (like modification date) are easier to see.
- Long file names are fully visible.
- More file information can be seen at a glance.

Fixes #441

🤖 Generated with [Gemini Code](https://gemini.google.com/code)