### PR TITLE
feat: AIを試すメニュー選択時にAIを自動保存する

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -210,6 +210,7 @@ class MenuBar extends React.Component {
             'getSaveToComputerHandler',
             'getSaveAIHandler',
             'getSaveAIAsHandler',
+            'getTestAIHandler',
             'handleAISaveFinished',
             'handleAISaveAsFinished',
             'handleAISaveError',
@@ -349,6 +350,19 @@ class MenuBar extends React.Component {
     }
     getSaveAIAsHandler (downloadProjectCallback) {
         return () => {
+            // Set AI save status to 'saving'
+            this.props.onSetAiSaveStatus('saving');
+            // Call download callback
+            downloadProjectCallback();
+        };
+    }
+    getTestAIHandler (downloadProjectCallback) {
+        return () => {
+            // Option B: Save after displaying the modal
+            // Open the Koshien test modal
+            this.props.onOpenKoshienTestModal();
+            // Close the Koshien menu
+            this.props.onRequestCloseKoshien();
             // Set AI save status to 'saving'
             this.props.onSetAiSaveStatus('saving');
             // Call download callback
@@ -918,15 +932,23 @@ class MenuBar extends React.Component {
                                         </RubyDownloader>
                                     </MenuSection>
                                     <MenuSection>
-                                        <MenuItem
-                                            onClick={this.props.onOpenKoshienTestModal}
+                                        <RubyDownloader
+                                            onSaveError={this.handleAISaveError}
+                                            onSaveFinished={this.handleAISaveFinished}
                                         >
-                                            <FormattedMessage
-                                                defaultMessage="Test AI"
-                                                description="Menu bar item for testing AI"
-                                                id="gui.menuBar.testAI"
-                                            />
-                                        </MenuItem>
+                                            {(className, downloadProjectCallback) => (
+                                                <MenuItem
+                                                    className={className}
+                                                    onClick={this.getTestAIHandler(downloadProjectCallback)}
+                                                >
+                                                    <FormattedMessage
+                                                        defaultMessage="Test AI"
+                                                        description="Menu bar item for testing AI"
+                                                        id="gui.menuBar.testAI"
+                                                    />
+                                                </MenuItem>
+                                            )}
+                                        </RubyDownloader>
                                     </MenuSection>
                                     <MenuSection>
                                         <MenuItem


### PR DESCRIPTION
「AIを試す」メニューを選択したとき、AIを試すモーダルを表示した後、AIを自動保存する機能を追加しました。

詳細は Issue #443 を参照してください。

- 「AIを試す」メニューアイテムを RubyDownloader でラップ
- モーダルを開くと同時に保存処理（downloadProjectCallback）をトリガー
- モーダル表示時にメニューを即座に閉じるように変更

🤖 Generated with [Gemini Code](https://gemini.google.com/code)

Co-Authored-By: Gemini <noreply@google.com>