### PR TITLE
feat: update scratch-vm dependency to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#c5a5d82450e9b74385682f948370178ac75efc9a",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#cd466dd621d53426fd6348d8b5730b175dd8a912",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
## Summary
Update  scratch-vm  dependency to include improved Mesh V2 broadcast timing using frame synchronization.

## Changes
- Updated  package-lock.json  to reference  scratch-vm  commit  cd466dd621d53426fd6348d8b5730b175dd8a912 .

## Purpose
This update addresses the issue where multiple broadcasts fired in the same frame would cause message processing loss.

Closes smalruby/smalruby3-gui#475

Co-Authored-By: Gemini <noreply@google.com>