### PR TITLE
feat: remove dependency on MESH_MAX_CONNECTION_TIME_SECONDS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,18 @@ GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
 # Google API Key (for Picker API)
 # Example: AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567
 GOOGLE_API_KEY=your-api-key-here
+
+# Mesh V2 Extension Configuration
+# See https://github.com/smalruby/scratch-vm/tree/develop/ for backend setup
+
+# AppSync GraphQL API Endpoint (Production)
+# Example: https://xxxxx.appsync-api.ap-northeast-1.amazonaws.com/graphql
+MESH_GRAPHQL_ENDPOINT=https://example.appsync-api.ap-northeast-1.amazonaws.com/graphql
+
+# AppSync API Key (Production)
+# Example: da2-xxxxx
+MESH_API_KEY=da2-your-api-key
+
+# AWS Region (Production)
+# Example: ap-northeast-1
+MESH_AWS_REGION=ap-northeast-1

--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#2d8985033a78efd1ac9b681703081a71dd960ec1",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#fc8016f4999770b796cfa5a3eea32a8f7eb1188f",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,8 +70,7 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.GOOGLE_API_KEY': `"${process.env.GOOGLE_API_KEY || ''}"`,
         'process.env.MESH_GRAPHQL_ENDPOINT': `"${process.env.MESH_GRAPHQL_ENDPOINT || ''}"`,
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
-        'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
-        'process.env.MESH_MAX_CONNECTION_TIME_SECONDS': Number(process.env.MESH_MAX_CONNECTION_TIME_SECONDS || 3000)
+        'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [


### PR DESCRIPTION
## Summary
Remove environment variable `MESH_MAX_CONNECTION_TIME_SECONDS` from webpack configuration as it is now calculated from the GraphQL API response.

## Implementation details
- Remove `MESH_MAX_CONNECTION_TIME_SECONDS` from `webpack.config.js`.
- Update `.env.example` with Mesh V2 configuration.

## Note
This change depends on the corresponding changes in `scratch-vm` (see smalruby/scratch-vm#57).

Co-Authored-By: Gemini <noreply@google.com>