### PR TITLE
feat: update scratch-vm dependency to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#fc8016f4999770b796cfa5a3eea32a8f7eb1188f",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#c601c859cb07e383435ff0e681af775471203591",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
## Summary
Updated `package-lock.json` to reference the latest commit of `scratch-vm`.

## Implementation details
- Updated `scratch-vm` dependency hash in `package-lock.json`.
- Ensures that the GUI uses the latest VM features and fixes.

🤖 Generated with [Gemini Code](https://gemini.google.com/code)

Co-Authored-By: Gemini <noreply@google.com>