### PR TITLE
fix: remove unused mesh.fireMeshEvent translation key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#78a12a6e4a3aa3a863dad669d6be48c3b23cc4f9",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#58067e48277041a269b8438a83a4ccbf1382c732",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -42,7 +42,6 @@ export default {
     'mesh.expiresAtV2': ' （{ TIME }までつかえます）',
     'mesh.notConnectedV2': 'メッシュにせつぞくしていません',
     'mesh.joinedMesh': 'メッシュにさんかしました 【{ MESH_ID }】',
-    'mesh.fireMeshEvent': '[BROADCAST_OPTION] をおくる',
     'gui.smalruby3.extension.smalrubotS1.name': 'スモウルボットS1 (エス1)',
     'gui.smalruby3.extension.smalrubotS1.description': 'スモウルボットS1 (エス1) をせいぎょする。',
     'gui.smalruby3.extension.smalrubotS1.connectingMessage': 'スモウルボットS1 (エス1) にせつぞくしています。',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -87,7 +87,6 @@ export default {
     'mesh.joinedMeshV2': 'メッシュに参加しました 【{ MESH_ID }】',
     'mesh.expiresAtV2': ' （{ TIME }まで使えます）',
     'mesh.notConnectedV2': 'メッシュに接続していません',
-    'mesh.fireMeshEvent': '[BROADCAST_OPTION] を送る',
     'gui.smalruby3.extension.smalrubotS1.name': 'スモウルボットS1',
     'gui.smalruby3.extension.smalrubotS1.description': 'スモウルボットS1を制御する。',
     'gui.smalruby3.extension.smalrubotS1.connectingMessage': 'スモウルボットS1に接続しています。',


### PR DESCRIPTION
Cleanup of redundant translation strings after the removal of the fireMeshEvent block in scratch-vm.