### PR TITLE
Update scratch-vm dependency to include expired group handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#58067e48277041a269b8438a83a4ccbf1382c732",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#b576ac1ffa39c5c2a4c0b89be8d321537a8df9dd",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
## Summary
Updates the `scratch-vm` dependency to the latest commit which includes improvements for handling expired Mesh V2 groups.

## Changes
- Updated `package-lock.json` to reference the latest `scratch-vm` commit.
- This incorporates the fixes from [smalruby/scratch-vm#66](https://github.com/smalruby/scratch-vm/issues/66).

Co-Authored-By: Gemini <noreply@google.com>