### PR TITLE
feat: update scratch-vm dependency to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#b576ac1ffa39c5c2a4c0b89be8d321537a8df9dd",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#7c078c29c10de2573482df9420289db14569a6d5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
This PR updates the scratch-vm dependency to the latest commit on the develop branch.

### Summary
- Updated package-lock.json to reference latest scratch-vm changes
- Ensures compatibility with recent scratch-vm modifications

🤖 Generated with [Gemini Code](https://gemini.google.com/code)