### PR TITLE
fix: update scratch-vm dependency for Mesh V2 last-modified logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#226d707bc5199efd693545012f8a4f14744f1d6c",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#3eb2d865210b7a3efb908762c56723d18671a591",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
## Summary
Updates `scratch-vm` dependency to include the fix for ensuring Mesh V2 returns the most recently modified value when multiple nodes share the same data name.

## Related Issues
- Closes smalruby/smalruby3-gui#492
- Depends on smalruby/scratch-vm#71 (already merged)

## Implementation Details
Updated `package-lock.json` by running:
```bash
docker compose run --rm gui bash -c "npm update scratch-vm && npm link scratch-vm"
```

Co-Authored-By: Gemini <noreply@google.com>