### PR TITLE
feat: add Mesh v2 configuration parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,10 +24,6 @@ MESH_API_KEY=da2-your-api-key
 # Example: ap-northeast-1
 MESH_AWS_REGION=ap-northeast-1
 
-# Maximum connection time in seconds
-# Default: 300 (5 minutes)
-MESH_MAX_CONNECTION_TIME_SECONDS=300
-
 # Data update interval in milliseconds
 # Default: 1000
 MESH_DATA_UPDATE_INTERVAL_MS=1000

--- a/.env.example
+++ b/.env.example
@@ -31,11 +31,3 @@ MESH_DATA_UPDATE_INTERVAL_MS=1000
 # Event batch interval in milliseconds
 # Default: 1000
 MESH_EVENT_BATCH_INTERVAL_MS=1000
-
-# Host heartbeat interval in seconds
-# Default: 60 (60 seconds)
-MESH_HOST_HEARTBEAT_INTERVAL_SECONDS=15
-
-# Member heartbeat interval in seconds
-# Default: 60 (60 seconds)
-MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS=15

--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,45 @@ MESH_GRAPHQL_ENDPOINT=https://example.appsync-api.ap-northeast-1.amazonaws.com/g
 MESH_API_KEY=da2-your-api-key
 
 # AWS Region (Production)
+
 # Example: ap-northeast-1
+
 MESH_AWS_REGION=ap-northeast-1
+
+
+
+# Connection timeout in milliseconds
+
+# Default: 3000000 (50 minutes)
+
+# Production: 1500000 (25 minutes)
+
+MESH_CONNECTION_TIMEOUT_MS=3000000
+
+
+
+# Data update interval in milliseconds
+
+# Default: 250
+
+# Production: 1000
+
+MESH_DATA_UPDATE_INTERVAL_MS=250
+
+
+
+# Event batch interval in milliseconds
+
+# Default: 250
+
+# Production: 1000
+
+MESH_EVENT_BATCH_INTERVAL_MS=250
+
+
+
+# Host heartbeat interval in milliseconds
+
+# Default: 15000 (15 seconds)
+
+MESH_HOST_HEARTBEAT_INTERVAL_MS=15000

--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,11 @@ MESH_AWS_REGION=ap-northeast-1
 
 
 
-# Connection timeout in milliseconds
+# Maximum connection time in seconds
 
-# Default: 3000000 (50 minutes)
+# Default: 300 (5 minutes)
 
-# Production: 1500000 (25 minutes)
-
-MESH_CONNECTION_TIMEOUT_MS=3000000
+MESH_MAX_CONNECTION_TIME_SECONDS=300
 
 
 
@@ -58,8 +56,18 @@ MESH_EVENT_BATCH_INTERVAL_MS=250
 
 
 
-# Host heartbeat interval in milliseconds
+# Host heartbeat interval in seconds
 
-# Default: 15000 (15 seconds)
+# Default: 15 (15 seconds)
 
-MESH_HOST_HEARTBEAT_INTERVAL_MS=15000
+MESH_HOST_HEARTBEAT_INTERVAL_SECONDS=15
+
+
+
+# Member heartbeat interval in seconds
+
+# Default: 15 (15 seconds)
+
+MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS=15
+
+

--- a/.env.example
+++ b/.env.example
@@ -21,53 +21,25 @@ MESH_GRAPHQL_ENDPOINT=https://example.appsync-api.ap-northeast-1.amazonaws.com/g
 MESH_API_KEY=da2-your-api-key
 
 # AWS Region (Production)
-
 # Example: ap-northeast-1
-
 MESH_AWS_REGION=ap-northeast-1
 
-
-
 # Maximum connection time in seconds
-
 # Default: 300 (5 minutes)
-
 MESH_MAX_CONNECTION_TIME_SECONDS=300
 
-
-
 # Data update interval in milliseconds
-
-# Default: 250
-
-# Production: 1000
-
-MESH_DATA_UPDATE_INTERVAL_MS=250
-
-
+# Default: 1000
+MESH_DATA_UPDATE_INTERVAL_MS=1000
 
 # Event batch interval in milliseconds
-
-# Default: 250
-
-# Production: 1000
-
-MESH_EVENT_BATCH_INTERVAL_MS=250
-
-
+# Default: 1000
+MESH_EVENT_BATCH_INTERVAL_MS=1000
 
 # Host heartbeat interval in seconds
-
-# Default: 15 (15 seconds)
-
+# Default: 60 (60 seconds)
 MESH_HOST_HEARTBEAT_INTERVAL_SECONDS=15
 
-
-
 # Member heartbeat interval in seconds
-
-# Default: 15 (15 seconds)
-
+# Default: 60 (60 seconds)
 MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS=15
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#03a77cd3da0ab0578e3931b2cde9e76e9daa77c3",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#fbc79499adec7f15d5685c597c19419355a293d2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,10 +71,13 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.MESH_GRAPHQL_ENDPOINT': `"${process.env.MESH_GRAPHQL_ENDPOINT || ''}"`,
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
         'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
-        'process.env.MESH_CONNECTION_TIMEOUT_MS': `"${process.env.MESH_CONNECTION_TIMEOUT_MS || ''}"`,
+        'process.env.MESH_MAX_CONNECTION_TIME_SECONDS': `"${process.env.MESH_MAX_CONNECTION_TIME_SECONDS || ''}"`,
         'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
         'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
-        'process.env.MESH_HOST_HEARTBEAT_INTERVAL_MS': `"${process.env.MESH_HOST_HEARTBEAT_INTERVAL_MS || ''}"`
+        'process.env.MESH_HOST_HEARTBEAT_INTERVAL_SECONDS':
+            `"${process.env.MESH_HOST_HEARTBEAT_INTERVAL_SECONDS || ''}"`,
+        'process.env.MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS':
+            `"${process.env.MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,6 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.MESH_GRAPHQL_ENDPOINT': `"${process.env.MESH_GRAPHQL_ENDPOINT || ''}"`,
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
         'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
-        'process.env.MESH_MAX_CONNECTION_TIME_SECONDS': `"${process.env.MESH_MAX_CONNECTION_TIME_SECONDS || ''}"`,
         'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
         'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
         'process.env.MESH_HOST_HEARTBEAT_INTERVAL_SECONDS':

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,11 +72,7 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
         'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
         'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
-        'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
-        'process.env.MESH_HOST_HEARTBEAT_INTERVAL_SECONDS':
-            `"${process.env.MESH_HOST_HEARTBEAT_INTERVAL_SECONDS || ''}"`,
-        'process.env.MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS':
-            `"${process.env.MESH_MEMBER_HEARTBEAT_INTERVAL_SECONDS || ''}"`
+        'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,11 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.GOOGLE_API_KEY': `"${process.env.GOOGLE_API_KEY || ''}"`,
         'process.env.MESH_GRAPHQL_ENDPOINT': `"${process.env.MESH_GRAPHQL_ENDPOINT || ''}"`,
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
-        'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`
+        'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
+        'process.env.MESH_CONNECTION_TIMEOUT_MS': `"${process.env.MESH_CONNECTION_TIMEOUT_MS || ''}"`,
+        'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
+        'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
+        'process.env.MESH_HOST_HEARTBEAT_INTERVAL_MS': `"${process.env.MESH_HOST_HEARTBEAT_INTERVAL_MS || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [


### PR DESCRIPTION
Add missing Mesh v2 configuration parameters to .env.example and webpack.config.js. This ensures consistency with the recent changes in scratch-vm.