### PR TITLE
feat: add MESH_PERIODIC_DATA_SYNC_INTERVAL_MS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ MESH_DATA_UPDATE_INTERVAL_MS=1000
 # Event batch interval in milliseconds
 # Default: 1000
 MESH_EVENT_BATCH_INTERVAL_MS=1000
+
+# Periodic data sync interval in milliseconds
+# Default: 15000 (15 seconds)
+MESH_PERIODIC_DATA_SYNC_INTERVAL_MS=15000

--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#fbc79499adec7f15d5685c597c19419355a293d2",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#8b640a0a02e3e49b85365b60e0159c7d4f3530b6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,8 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         'process.env.MESH_API_KEY': `"${process.env.MESH_API_KEY || ''}"`,
         'process.env.MESH_AWS_REGION': `"${process.env.MESH_AWS_REGION || ''}"`,
         'process.env.MESH_DATA_UPDATE_INTERVAL_MS': `"${process.env.MESH_DATA_UPDATE_INTERVAL_MS || ''}"`,
-        'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`
+        'process.env.MESH_EVENT_BATCH_INTERVAL_MS': `"${process.env.MESH_EVENT_BATCH_INTERVAL_MS || ''}"`,
+        'process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS': `"${process.env.MESH_PERIODIC_DATA_SYNC_INTERVAL_MS || ''}"`
     }))
     .addPlugin(new CopyWebpackPlugin({
         patterns: [


### PR DESCRIPTION
## Summary
This PR adds configuration for the periodic data synchronization interval in Mesh V2.

## Implementation Details
- Updated `webpack.config.js` to inject `MESH_PERIODIC_DATA_SYNC_INTERVAL_MS` into the browser environment.
- Updated `.env.example` with the new variable.
- This works in conjunction with recent changes in `scratch-vm` that use this variable to control the frequency of full state reconciliation.

## Related PRs
- smalruby/scratch-vm#81 (Implements the logic in the VM)

Co-Authored-By: Gemini <noreply@google.com>