### PR TITLE
feat: add koshien.set_message API support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#74b5d9ee1fc2189b680fefecd4b17d0d931b89c6",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#bcb0cce40b7c5a7935e38fca611539b750b34781",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/src/containers/ruby-tab/koshien-snippets.json
+++ b/src/containers/ruby-tab/koshien-snippets.json
@@ -3,6 +3,10 @@
         "snippet": "koshien.connect_game(name: ${1:\"player1\"})",
         "description": "プレイヤー名を (player1) にして、ゲームサーバへ接続する"
     },
+    "koshien.set_message": {
+        "snippet": "koshien.set_message(${1:\"hello\"})",
+        "description": "メッセージを (hello) にする"
+    },
     "koshien.move_to": {
         "snippet": "koshien.move_to(${1:\"0:0\"})",
         "description": "座標 (0:0) に移動する"

--- a/src/lib/ruby-generator/koshien.js
+++ b/src/lib/ruby-generator/koshien.js
@@ -106,7 +106,7 @@ export default function (Generator) {
     };
 
     Generator.koshien_object = function (block) {
-        const object = Generator.quote_(block.fields.OBJECT.value);
+        const object = Generator.quote_(Generator.getFieldValue(block, 'OBJECT') || 'unknown');
         return [`koshien.object(${object})`];
     };
 

--- a/src/lib/ruby-generator/koshien.js
+++ b/src/lib/ruby-generator/koshien.js
@@ -106,8 +106,13 @@ export default function (Generator) {
     };
 
     Generator.koshien_object = function (block) {
-        const object = Generator.quote_(Generator.getFieldValue(block, 'OBJECT') || 'unknown');
+        const object = Generator.quote_(block.fields.OBJECT.value);
         return [`koshien.object(${object})`];
+    };
+
+    Generator.koshien_setMessage = function (block) {
+        const message = Generator.valueToCode(block, 'MESSAGE', Generator.ORDER_NONE) || Generator.quote_('hello');
+        return `koshien.set_message(${message})\n`;
     };
 
     return Generator;

--- a/src/lib/ruby-to-blocks-converter/koshien.js
+++ b/src/lib/ruby-to-blocks-converter/koshien.js
@@ -303,6 +303,16 @@ const KoshienConverter = {
             converter.addField(block, 'OBJECT', args[0]);
             return block;
         });
+
+        converter.registerOnSend(Koshien, 'set_message', 1, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'koshien_setMessage', 'statement');
+            converter.addTextInput(block, 'MESSAGE', args[0], 'hello');
+            return block;
+        });
     }
 };
 

--- a/test/integration/ruby-tab/extension_koshien.test.js
+++ b/test/integration/ruby-tab/extension_koshien.test.js
@@ -44,6 +44,7 @@ describe('Ruby Tab: Koshien extension blocks', () => {
             koshien.locate_objects(result: list("$地形・アイテム"), sq_size: 3, cent: "1:2", objects: "ABCD")
             koshien.locate_objects(result: nil, sq_size: 3, cent: "1:2", objects: "ABCD")
             koshien.turn_over
+            koshien.set_message("こんにちは")
 
             koshien.position_of_x("0:1")
 

--- a/test/unit/lib/ruby-to-blocks-converter/koshien.test.js
+++ b/test/unit/lib/ruby-to-blocks-converter/koshien.test.js
@@ -1,0 +1,58 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    convertAndExpectRubyBlockError,
+    rubyToExpected,
+    expectedInfo
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/Koshien', () => {
+    let converter;
+    let target;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        target = null;
+    });
+
+    test('koshien_setMessage', () => {
+        let code;
+        let expected;
+
+        code = 'koshien.set_message("hello")';
+        expected = [
+            {
+                opcode: 'koshien_setMessage',
+                inputs: [
+                    {
+                        name: 'MESSAGE',
+                        block: expectedInfo.makeText('hello')
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        code = 'koshien.set_message(x)';
+        expected = [
+            {
+                opcode: 'koshien_setMessage',
+                inputs: [
+                    {
+                        name: 'MESSAGE',
+                        block: rubyToExpected(converter, target, 'x')[0],
+                        shadow: expectedInfo.makeText('hello')
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+
+        [
+            'koshien.set_message()',
+            'koshien.set_message("hello", "world")'
+        ].forEach(s => {
+            convertAndExpectRubyBlockError(converter, target, s);
+        });
+    });
+});


### PR DESCRIPTION
Implementation of koshien.set_message API support.

- Added Ruby code generator for koshien.set_message
- Added Ruby-to-Blocks converter for koshien.set_message
- Added unit test for the converter
- Updated integration test to include set_message

Depends on smalruby/scratch-vm#86

Closes #506