### PR TITLE
docs: update Mesh helpLink to point to smalruby.app wiki

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -399,7 +399,7 @@ const extensions = [
                 id="gui.smalruby3.extension.mesh.connectingMessage"
             />
         ),
-        helpLink: 'https://github.com/smalruby/smalruby3-gui/wiki/MeshV2'
+        helpLink: 'https://github.com/smalruby/smalruby.app/wiki/Mesh'
     },
     {
         name: (


### PR DESCRIPTION
The meshV2 documentation has been moved to the smalruby.app wiki for better visibility and accessibility for beginners.

This change updates the helpLink in the extension library to point to the new location: https://github.com/smalruby/smalruby.app/wiki/Mesh