### PR TITLE
feat: update scratch-vm dependency (polling fallback & mesh v2 fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,7 +28942,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#68dda6d1523e0e26610180ba23907bf16685ad03",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#dcf613e66627683ad97a7d64cad65de33d3463f7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
### Summary
Update `scratch-vm` dependency to include the latest improvements for Mesh V2, specifically the robust polling fallback mechanism and associated bug fixes.

### Implementation details
- Updated `package-lock.json` to reference the latest `develop` commit of `scratch-vm`.
- This ensures `smalruby3-gui` utilizes the refactored event handling logic and cost-efficient polling.

### Related Changes
These changes depend on the latest updates in:
- `smalruby/scratch-vm` (polling fallback implementation)
- `smalruby/mesh-v2` (AppSync schema and function fixes)