### PR TITLE
fix: correctly convert variable character access to letter_of block

### DIFF
--- a/src/lib/ruby-to-blocks-converter/operators.js
+++ b/src/lib/ruby-to-blocks-converter/operators.js
@@ -15,7 +15,7 @@ const OperatorsConverter = {
             return converter._changeBlock(args[0], 'operator_random', 'value');
         });
 
-        converter.registerOnSend(['string', 'block'], '[]', 1, params => {
+        converter.registerOnSend(['string', 'block', 'variable'], '[]', 1, params => {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 

--- a/src/lib/ruby-to-blocks-converter/variables.js
+++ b/src/lib/ruby-to-blocks-converter/variables.js
@@ -160,9 +160,13 @@ const VariablesConverter = {
             const {receiver, args} = params;
             if (!converter._isNumberOrBlock(args[0])) return null;
 
-            const block = converter._changeBlock(receiver, 'data_itemoflist', 'value');
-            converter._addNumberInput(block, 'INDEX', 'math_integer', args[0], 1);
-            return block;
+            if (converter._isBlock(receiver) && converter.isListBlock(receiver)) {
+                const block = converter._changeBlock(receiver, 'data_itemoflist', 'value');
+                converter._addNumberInput(block, 'INDEX', 'math_integer', args[0], 1);
+                return block;
+            }
+
+            return null;
         });
 
         converter.registerOnSend('variable', 'index', 1, params => {

--- a/test/unit/lib/ruby-to-blocks-converter/variables.test.js
+++ b/test/unit/lib/ruby-to-blocks-converter/variables.test.js
@@ -44,6 +44,35 @@ describe('RubyToBlocksConverter/Variables', () => {
                 convertAndExpectToEqualBlocks(converter, target, code, expected);
             });
 
+            test('operator_letter_of', () => {
+                const code = `${varName}[0]`;
+                const expected = [
+                    {
+                        opcode: 'operator_letter_of',
+                        inputs: [
+                            {
+                                name: 'STRING',
+                                block: {
+                                    opcode: 'data_variable',
+                                    fields: [
+                                        {
+                                            name: 'VARIABLE',
+                                            variable: varName
+                                        }
+                                    ]
+                                },
+                                shadow: expectedInfo.makeText('apple')
+                            },
+                            {
+                                name: 'LETTER',
+                                block: expectedInfo.makeNumber(1)
+                            }
+                        ]
+                    }
+                ];
+                convertAndExpectToEqualBlocks(converter, target, code, expected);
+            });
+
             test('data_setvariableto', () => {
                 let code;
                 let expected;


### PR DESCRIPTION
## Summary
This PR fixes issue #464 where character access on a regular variable (e.g., `$my_variable[0]`) was incorrectly converted to a list item block (`data_itemoflist`) instead of a character access block (`operator_letter_of`).

## Implementation details
- **variables.js**: The `[]` handler for the `variable` type was overly broad, catching all character access. It has been modified to only return a `data_itemoflist` block if the receiver is actually a list block (`isListBlock`). Otherwise, it returns `null` to allow other handlers to process it.
- **operators.js**: The `[]` handler (which creates `operator_letter_of`) has been updated to accept the `variable` type in addition to `string` and `block`.

## Test coverage
- Added a new test case to `test/unit/lib/ruby-to-blocks-converter/variables.test.js` that verifies `$variable[0]` converts to `operator_letter_of`.
- Verified that existing list-related tests (`list("$var")[1]`) still pass.
- Total tests passed: 101 (42 in variables.test.js, 59 in operaters.test.js).

## Usage examples
Ruby code:
```ruby
$my_variable[0]
```
Now correctly converts to:
- Opcode: `operator_letter_of`
- String input: `data_variable` (pointing to `$my_variable`)
- Letter input: `1`

## Breaking changes
None.

Fixes #464

Co-Authored-By: Gemini <noreply@google.com>