### PR TITLE
feat: add default hidden functionality to extension library

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
     "gapi",
     "googleusercontent",
     "Hira",
+    "mbit",
     "smalrubot"
   ],
   "ignorePaths": [

--- a/src/components/koshien-test-modal/koshien-test-modal.css
+++ b/src/components/koshien-test-modal/koshien-test-modal.css
@@ -21,3 +21,16 @@
     flex: 1;
     min-height: 0;
 }
+
+.reload-button {
+    font-weight: normal;
+    font-size: 0.75rem;
+}
+
+.stop-icon {
+    position: relative;
+    margin: 0.25rem;
+    user-select: none;
+    transform-origin: 50%;
+    transform: rotate(45deg);
+}

--- a/src/components/koshien-test-modal/koshien-test-modal.jsx
+++ b/src/components/koshien-test-modal/koshien-test-modal.jsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {defineMessages, injectIntl, intlShape, FormattedMessage} from 'react-intl';
 
 import Box from '../box/box.jsx';
+import Button from '../button/button.jsx';
 import Modal from '../../containers/modal.jsx';
+
+import reloadIcon from '../../lib/assets/icon--reload.svg';
+import stopIcon from '../close-button/icon--close.svg';
 
 import styles from './koshien-test-modal.css';
 
@@ -33,16 +37,42 @@ const KoshienTestModal = props => {
         setLoading(false);
     }, []);
 
+    const headerActions = loading ? (
+        <Button
+            className={styles.reloadButton}
+            iconClassName={styles.stopIcon}
+            iconSrc={stopIcon}
+            onClick={handleStop}
+        >
+            <FormattedMessage
+                defaultMessage="Stop"
+                description="Stop button in modal"
+                id="gui.modal.stop"
+            />
+        </Button>
+    ) : (
+        <Button
+            className={styles.reloadButton}
+            iconSrc={reloadIcon}
+            onClick={handleReload}
+        >
+            <FormattedMessage
+                defaultMessage="Reload"
+                description="Reload button in modal"
+                id="gui.modal.reload"
+            />
+        </Button>
+    );
+
     return (
         <Modal
             className={styles.modalContent}
             contentLabel={intl.formatMessage(messages.title)}
             fullScreen
+            headerActions={headerActions}
             headerClassName={styles.header}
             id="koshienTestModal"
             loading={loading}
-            onReload={handleReload}
-            onStop={handleStop}
             onRequestClose={onRequestClose}
         >
             <Box

--- a/src/components/library/library.jsx
+++ b/src/components/library/library.jsx
@@ -199,6 +199,7 @@ class LibraryComponent extends React.Component {
             <Modal
                 fullScreen
                 contentLabel={this.props.title}
+                headerActions={this.props.headerActions}
                 id={this.props.id}
                 onRequestClose={this.handleClose}
             >
@@ -275,6 +276,7 @@ LibraryComponent.propTypes = {
         /* eslint-enable react/no-unused-prop-types, lines-around-comment */
     ),
     filterable: PropTypes.bool,
+    headerActions: PropTypes.node,
     id: PropTypes.string.isRequired,
     intl: intlShape.isRequired,
     onItemMouseEnter: PropTypes.func,

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -156,6 +156,20 @@ $sides: 20rem;
     margin-right: -4.75rem;
 }
 
+/* Header actions (generic) */
+.header-item-actions {
+    padding: 0;
+    z-index: 1;
+}
+
+[dir="ltr"] .header-item-actions {
+    margin-left: -4.75rem;
+}
+
+[dir="rtl"] .header-item-actions {
+    margin-right: -4.75rem;
+}
+
 .reload-button {
     font-weight: normal;
     font-size: 0.75rem;

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
 import ReactModal from 'react-modal';
 import {FormattedMessage} from 'react-intl';
 
@@ -10,8 +9,6 @@ import CloseButton from '../close-button/close-button.jsx';
 
 import backIcon from '../../lib/assets/icon--back.svg';
 import helpIcon from '../../lib/assets/icon--help.svg';
-import reloadIcon from '../../lib/assets/icon--reload.svg';
-import stopIcon from '../close-button/icon--close.svg';
 
 import styles from './modal.css';
 
@@ -76,46 +73,6 @@ const ModalComponent = props => (
                         {props.headerActions}
                     </div>
                 ) : null}
-                {props.loading && props.onStop ? (
-                    <div
-                        className={classNames(
-                            styles.headerItem,
-                            styles.headerItemReload
-                        )}
-                    >
-                        <Button
-                            className={styles.reloadButton}
-                            iconClassName={styles.stopIcon}
-                            iconSrc={stopIcon}
-                            onClick={props.onStop}
-                        >
-                            <FormattedMessage
-                                defaultMessage="Stop"
-                                description="Stop button in modal"
-                                id="gui.modal.stop"
-                            />
-                        </Button>
-                    </div>
-                ) : (props.onReload ? (
-                    <div
-                        className={classNames(
-                            styles.headerItem,
-                            styles.headerItemReload
-                        )}
-                    >
-                        <Button
-                            className={styles.reloadButton}
-                            iconSrc={reloadIcon}
-                            onClick={props.onReload}
-                        >
-                            <FormattedMessage
-                                defaultMessage="Reload"
-                                description="Reload button in modal"
-                                id="gui.modal.reload"
-                            />
-                        </Button>
-                    </div>
-                ) : null)}
                 <div
                     className={classNames(
                         styles.headerItem,
@@ -166,8 +123,6 @@ ModalComponent.propTypes = {
     isRtl: PropTypes.bool,
     loading: PropTypes.bool,
     onHelp: PropTypes.func,
-    onReload: PropTypes.func,
-    onStop: PropTypes.func,
     onRequestClose: PropTypes.func
 };
 

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -66,6 +66,16 @@ const ModalComponent = props => (
                     ) : null}
                     {props.contentLabel}
                 </div>
+                {props.headerActions ? (
+                    <div
+                        className={classNames(
+                            styles.headerItem,
+                            styles.headerItemActions
+                        )}
+                    >
+                        {props.headerActions}
+                    </div>
+                ) : null}
                 {props.loading && props.onStop ? (
                     <div
                         className={classNames(
@@ -150,6 +160,7 @@ ModalComponent.propTypes = {
         PropTypes.object
     ]).isRequired,
     fullScreen: PropTypes.bool,
+    headerActions: PropTypes.node,
     headerClassName: PropTypes.string,
     headerImage: PropTypes.string,
     isRtl: PropTypes.bool,

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import React from 'react';
 import ReactModal from 'react-modal';
 import {FormattedMessage} from 'react-intl';
 

--- a/src/containers/extension-library.css
+++ b/src/containers/extension-library.css
@@ -1,0 +1,25 @@
+@import "../components/modal/modal.css";
+
+.show-all-extensions-label {
+    display: flex;
+    align-items: center;
+    font-size: 0.75rem;
+    font-weight: normal;
+    cursor: pointer;
+    user-select: none;
+    color: $ui-white;
+    white-space: nowrap;
+    padding: 1rem;
+}
+
+.show-all-extensions-checkbox {
+    cursor: pointer;
+}
+
+[dir="ltr"] .show-all-extensions-checkbox {
+    margin-right: 0.5rem;
+}
+
+[dir="rtl"] .show-all-extensions-checkbox {
+    margin-left: 0.5rem;
+}

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -71,12 +71,17 @@ class ExtensionLibrary extends React.PureComponent {
         const extensionsParam = query.get('extensions') || '';
         const showMeshV2 = extensionsParam.split(',').includes('meshV2');
 
+        const showAllExtensionsParam = query.get('showAllExtensions');
+        const showAllExtensions = showAllExtensionsParam === 'true' ? true :
+            showAllExtensionsParam === 'false' ? false :
+                this.props.showAllExtensions;
+
         const extensionLibraryThumbnailData = extensionLibraryContent
             .filter(extension => {
                 if (extension.extensionId === 'meshV2' && !showMeshV2) {
                     return false;
                 }
-                if (!this.props.showAllExtensions && extension.defaultHidden) {
+                if (!showAllExtensions && extension.defaultHidden) {
                     return false;
                 }
                 return true;
@@ -86,10 +91,17 @@ class ExtensionLibrary extends React.PureComponent {
                 ...extension
             }));
 
+        const checkboxLabel = this.props.intl.formatMessage({
+            defaultMessage: 'Show all extensions',
+            description: 'Checkbox label to show all extensions including hidden ones',
+            id: 'gui.extensionLibrary.showAllExtensions'
+        });
+
         const headerActions = (
             <label className={styles.showAllExtensionsLabel}>
                 <input
-                    checked={this.props.showAllExtensions}
+                    aria-label={checkboxLabel}
+                    checked={showAllExtensions}
                     className={styles.showAllExtensionsCheckbox}
                     type="checkbox"
                     onChange={this.handleToggleShowAllExtensions}

--- a/src/containers/extension-library.jsx
+++ b/src/containers/extension-library.jsx
@@ -2,12 +2,17 @@ import bindAll from 'lodash.bindall';
 import PropTypes from 'prop-types';
 import React from 'react';
 import VM from 'scratch-vm';
-import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import {connect} from 'react-redux';
+import {defineMessages, injectIntl, intlShape, FormattedMessage} from 'react-intl';
 
 import extensionLibraryContent from '../lib/libraries/extensions/index.jsx';
 
 import LibraryComponent from '../components/library/library.jsx';
 import extensionIcon from '../components/action-menu/icon--sprite.svg';
+
+import {toggleShowAllExtensions} from '../reducers/extension-filter';
+
+import styles from './extension-library.css';
 
 const messages = defineMessages({
     extensionTitle: {
@@ -37,8 +42,12 @@ class ExtensionLibrary extends React.PureComponent {
             }
         });
         bindAll(this, [
-            'handleItemSelect'
+            'handleItemSelect',
+            'handleToggleShowAllExtensions'
         ]);
+    }
+    handleToggleShowAllExtensions (event) {
+        this.props.onToggleShowAllExtensions(event.target.checked);
     }
     handleItemSelect (item) {
         const id = item.extensionId;
@@ -63,17 +72,41 @@ class ExtensionLibrary extends React.PureComponent {
         const showMeshV2 = extensionsParam.split(',').includes('meshV2');
 
         const extensionLibraryThumbnailData = extensionLibraryContent
-            .filter(extension => (
-                extension.extensionId !== 'meshV2' || showMeshV2
-            ))
+            .filter(extension => {
+                if (extension.extensionId === 'meshV2' && !showMeshV2) {
+                    return false;
+                }
+                if (!this.props.showAllExtensions && extension.defaultHidden) {
+                    return false;
+                }
+                return true;
+            })
             .map(extension => ({
                 rawURL: extension.iconURL || extensionIcon,
                 ...extension
             }));
+
+        const headerActions = (
+            <label className={styles.showAllExtensionsLabel}>
+                <input
+                    checked={this.props.showAllExtensions}
+                    className={styles.showAllExtensionsCheckbox}
+                    type="checkbox"
+                    onChange={this.handleToggleShowAllExtensions}
+                />
+                <FormattedMessage
+                    defaultMessage="Show all extensions"
+                    description="Checkbox label to show all extensions including hidden ones"
+                    id="gui.extensionLibrary.showAllExtensions"
+                />
+            </label>
+        );
+
         return (
             <LibraryComponent
                 data={extensionLibraryThumbnailData}
                 filterable={false}
+                headerActions={headerActions}
                 id="extensionLibrary"
                 title={this.props.intl.formatMessage(messages.extensionTitle)}
                 visible={this.props.visible}
@@ -88,8 +121,21 @@ ExtensionLibrary.propTypes = {
     intl: intlShape.isRequired,
     onCategorySelected: PropTypes.func,
     onRequestClose: PropTypes.func,
+    onToggleShowAllExtensions: PropTypes.func,
+    showAllExtensions: PropTypes.bool,
     visible: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired // eslint-disable-line react/no-unused-prop-types
 };
 
-export default injectIntl(ExtensionLibrary);
+const mapStateToProps = state => ({
+    showAllExtensions: state.scratchGui.extensionFilter.showAllExtensions
+});
+
+const mapDispatchToProps = dispatch => ({
+    onToggleShowAllExtensions: showAll => dispatch(toggleShowAllExtensions(showAll))
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(injectIntl(ExtensionLibrary));

--- a/src/containers/library-item.jsx
+++ b/src/containers/library-item.jsx
@@ -157,7 +157,7 @@ LibraryItem.propTypes = {
             md5ext: PropTypes.string // 3.0 library format
         })
     ),
-    id: PropTypes.number.isRequired,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     insetIconURL: PropTypes.string,
     internetConnectionRequired: PropTypes.bool,
     isPlaying: PropTypes.bool,

--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -61,6 +61,9 @@ import meshV2InsetIconURL from './mesh_v2/mesh-small.png';
 import meshV2ConnectionIconURL from './mesh_v2/mesh-illustration.png';
 import meshV2ConnectionSmallIconURL from './mesh_v2/mesh-small.png';
 
+import microbitMore from './microbitMore/index.jsx';
+import koshien from './koshien/index.jsx';
+
 const extensions = [
     {
         name: (
@@ -179,7 +182,8 @@ const extensions = [
                 id="gui.extension.makeymakey.description"
             />
         ),
-        featured: true
+        featured: true,
+        defaultHidden: true
     },
     {
         name: 'micro:bit',
@@ -195,6 +199,7 @@ const extensions = [
             />
         ),
         featured: true,
+        defaultHidden: true,
         disabled: false,
         bluetoothRequired: true,
         internetConnectionRequired: true,
@@ -211,6 +216,7 @@ const extensions = [
         ),
         helpLink: 'https://scratch.mit.edu/microbit'
     },
+    microbitMore,
     {
         name: 'LEGO MINDSTORMS EV3',
         extensionId: 'ev3',
@@ -225,6 +231,7 @@ const extensions = [
             />
         ),
         featured: true,
+        defaultHidden: true,
         disabled: false,
         bluetoothRequired: true,
         internetConnectionRequired: true,
@@ -255,6 +262,7 @@ const extensions = [
             />
         ),
         featured: true,
+        defaultHidden: true,
         disabled: false,
         bluetoothRequired: true,
         internetConnectionRequired: true,
@@ -286,6 +294,7 @@ const extensions = [
             />
         ),
         featured: true,
+        defaultHidden: true,
         disabled: false,
         bluetoothRequired: true,
         internetConnectionRequired: true,
@@ -317,6 +326,7 @@ const extensions = [
             />
         ),
         featured: true,
+        defaultHidden: true,
         disabled: false,
         bluetoothRequired: true,
         internetConnectionRequired: true,
@@ -435,14 +445,8 @@ const extensions = [
             />
         ),
         helpLink: 'https://github.com/smalruby/smalruby3-gui/wiki/SmalrubotS1'
-    }
+    },
+    koshien
 ];
-
-// Injected for extra extensions
-import microbitMore from './microbitMore/index.jsx';
-extensions.push(microbitMore);
-
-import koshien from './koshien/index.jsx';
-extensions.push(koshien);
 
 export default extensions;

--- a/src/lib/libraries/extensions/microbitMore/index.jsx
+++ b/src/lib/libraries/extensions/microbitMore/index.jsx
@@ -15,7 +15,7 @@ const version = 'v2-0.2.5';
 const entry = {
     get name () {
         return `${formatMessage({
-            defaultMessage: 'MicroBit More',
+            defaultMessage: 'micro:bit',
             description: 'Name of this extension',
             id: 'mbitMore.entry.name'
         })} (${version})`;
@@ -26,7 +26,7 @@ const entry = {
     insetIconURL: microbitMoreInsetIconURL,
     get description () {
         return formatMessage({
-            defaultMessage: 'Play with all functions of micro:bit.',
+            defaultMessage: 'Play with all functions of micro:bit with Microbit More.',
             description: "Description for the 'Microbit More' extension",
             id: 'mbitMore.entry.description'
         });

--- a/src/lib/libraries/extensions/microbitMore/translations.json
+++ b/src/lib/libraries/extensions/microbitMore/translations.json
@@ -1,18 +1,18 @@
 {
   "de": {
-    "mbitMore.entry.name": "MicroBit More",
+    "mbitMore.entry.name": "micro:bit",
     "mbitMore.entry.description": "Nutze alle Funktionen des micro:bit."
   },
   "en": {
-    "mbitMore.entry.name": "MicroBit More",
-    "mbitMore.entry.description": "Play with all functions of micro:bit."
+    "mbitMore.entry.name": "micro:bit",
+    "mbitMore.entry.description": "Play with all functions of micro:bit with Microbit More."
   },
   "ja": {
-    "mbitMore.entry.name": "MicroBit More",
-    "mbitMore.entry.description": "micro:bitのすべての機能で遊ぶ。"
+    "mbitMore.entry.name": "micro:bit",
+    "mbitMore.entry.description": "micro:bitのすべての機能で遊ぶ。 (Microbit More)"
   },
   "ja-Hira": {
-    "mbitMore.entry.name": "マイクロビット モア",
-    "mbitMore.entry.description": "マイクロビットのすべてのきのうであそぶ。"
+    "mbitMore.entry.name": "micro:bit",
+    "mbitMore.entry.description": "マイクロビットのすべてのきのうであそぶ。 (マイクロビット モア)"
   }
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -18,6 +18,7 @@ export default {
     "gui.smalruby3.telemetryOptIn.body1": "The Smalruby Team is always looking to better understand how Smalruby is used around the world. To help support this effort, you can allow Smalruby to automatically send usage information to the Smalruby Team.",
     "gui.smalruby3.telemetryOptIn.body2": "The information we collect includes language selection, blocks usage, and some events like saving, loading, and uploading a project. We DO NOT collect any personal information.",
     "gui.telemetryOptIn.buttonTextNo": "No, thanks",
+    "gui.extensionLibrary.showAllExtensions": "Show all extensions",
     'gui.smalruby3.rubyToBlocksConverter.couldNotConvertPrimitive': '"{ SOURCE }" could not be converted the block.',
     'gui.smalruby3.rubyToBlocksConverter.wrongInstruction': '"{ SOURCE }" is the wrong instruction.',
     "gui.smalruby3.telemetryOptIn.buttonTextYes": "Yes, I'd like to help improve Smalruby",

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -209,5 +209,6 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_contains': '(りんご) に (り) がふくまれる',
     'gui.smalruby3.blockDisplayModal.operator_mod': '(　) を (　) でわったあまり',
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) をししゃごにゅう',
-    'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [ぜったいち▼]'
+    'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [ぜったいち▼]',
+    'gui.extensionLibrary.showAllExtensions': 'すべてのかくちょうきのうをひょうじ'
 };

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -246,5 +246,6 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_contains': '(りんご) に (り) が含まれる',
     'gui.smalruby3.blockDisplayModal.operator_mod': '(　) を (　) で割った余り',
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) を四捨五入',
-    'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [絶対値▼]'
+    'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [絶対値▼]',
+    'gui.extensionLibrary.showAllExtensions': 'すべての拡張機能を表示'
 };

--- a/src/reducers/extension-filter.js
+++ b/src/reducers/extension-filter.js
@@ -1,0 +1,37 @@
+const TOGGLE_SHOW_ALL_EXTENSIONS = 'scratch-gui/extension-filter/TOGGLE_SHOW_ALL_EXTENSIONS';
+
+const SHOW_ALL_EXTENSIONS_KEY = 'smalruby:showAllExtensions';
+const savedShowAllExtensions = typeof window !== 'undefined' && window.localStorage ?
+    window.localStorage.getItem(SHOW_ALL_EXTENSIONS_KEY) === 'true' : false;
+
+const initialState = {
+    showAllExtensions: savedShowAllExtensions
+};
+
+const reducer = function (state, action) {
+    if (typeof state === 'undefined') state = initialState;
+    switch (action.type) {
+    case TOGGLE_SHOW_ALL_EXTENSIONS:
+        if (typeof window !== 'undefined' && window.localStorage) {
+            window.localStorage.setItem(SHOW_ALL_EXTENSIONS_KEY, action.showAllExtensions);
+        }
+        return Object.assign({}, state, {
+            showAllExtensions: action.showAllExtensions
+        });
+    default:
+        return state;
+    }
+};
+
+const toggleShowAllExtensions = function (showAllExtensions) {
+    return {
+        type: TOGGLE_SHOW_ALL_EXTENSIONS,
+        showAllExtensions: showAllExtensions
+    };
+};
+
+export {
+    reducer as default,
+    initialState as extensionFilterInitialState,
+    toggleShowAllExtensions
+};

--- a/src/reducers/gui.js
+++ b/src/reducers/gui.js
@@ -7,6 +7,7 @@ import connectionModalReducer, {connectionModalInitialState} from './connection-
 import customProceduresReducer, {customProceduresInitialState} from './custom-procedures';
 import blockDragReducer, {blockDragInitialState} from './block-drag';
 import editorTabReducer, {editorTabInitialState} from './editor-tab';
+import extensionFilterReducer, {extensionFilterInitialState} from './extension-filter';
 import hoveredTargetReducer, {hoveredTargetInitialState} from './hovered-target';
 import menuReducer, {menuInitialState} from './menus';
 import meshV2Reducer, {meshV2InitialState} from './mesh-v2';
@@ -45,6 +46,7 @@ const guiInitialState = {
     connectionModal: connectionModalInitialState,
     customProcedures: customProceduresInitialState,
     editorTab: editorTabInitialState,
+    extensionFilter: extensionFilterInitialState,
     mode: modeInitialState,
     hoveredTarget: hoveredTargetInitialState,
     stageSize: stageSizeInitialState,
@@ -131,6 +133,7 @@ const guiReducer = combineReducers({
     connectionModal: connectionModalReducer,
     customProcedures: customProceduresReducer,
     editorTab: editorTabReducer,
+    extensionFilter: extensionFilterReducer,
     mode: modeReducer,
     hoveredTarget: hoveredTargetReducer,
     stageSize: stageSizeReducer,

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -249,14 +249,24 @@ class SeleniumHelper {
      * @returns {Promise} A promise that resolves when the URI is loaded.
      */
     async loadUri (uri) {
+        const locale = 'locale=en';
         if (uri.indexOf('locale=') < 0) {
-            const locale = 'locale=en';
             if (uri.indexOf('?') >= 0) {
                 uri = uri.replace('?', `?${locale}&`);
             } else if (uri.indexOf('#') >= 0) {
                 uri = uri.replace('#', `?${locale}#`);
             } else {
                 uri = `${uri}?${locale}`;
+            }
+        }
+        if (uri.indexOf('showAllExtensions=') < 0) {
+            const showAllExtensions = 'showAllExtensions=true';
+            if (uri.indexOf('?') >= 0) {
+                uri = uri.replace('?', `?${showAllExtensions}&`);
+            } else if (uri.indexOf('#') >= 0) {
+                uri = uri.replace('#', `?${showAllExtensions}#`);
+            } else {
+                uri = `${uri}?${showAllExtensions}`;
             }
         }
 


### PR DESCRIPTION
This PR adds the ability to hide certain extensions by default in the extension library, as requested in smalruby/smalruby3-develop#18.

### Changes:
- **Redux**: Created `extension-filter.js` to manage `showAllExtensions` state and integrated it into `gui.js`.
- **Metadata**: Added `defaultHidden: true` to `makeymakey`, `microbit`, `ev3`, `boost`, `wedo2`, and `gdxfor` in `lib/libraries/extensions/index.jsx`.
- **Components**:
    - Updated `Modal` component to support `headerActions` prop (Generic pattern).
    - Updated `LibraryComponent` to pass `headerActions` to `Modal`.
    - Updated `ExtensionLibrary` container to provide the "Show all extensions" checkbox.
- **Styles**: Added `extension-library.css` and updated `modal.css`.
- **Localization**: Added `gui.extensionLibrary.showAllExtensions` to `en.js`, `ja.js`, and `ja-Hira.js`.

### Verification:
- Ran lint: `npm run test:lint` passed.
- Ran build: `npm run build` passed.

Fixes smalruby/smalruby3-develop#18