### PR TITLE
feat: show whole shape of blocks when mouse over the flyout

### DIFF
--- a/src/components/blocks/blocks.css
+++ b/src/components/blocks/blocks.css
@@ -74,6 +74,30 @@
     border-left: 1px solid $ui-black-transparent;
 }
 
+.blocks :global(.blocklyFlyout:hover) {
+    overflow: visible;
+    clip-path: inset(0 -100vw 0 0);
+    -webkit-clip-path: inset(0 -100vw 0 0);
+}
+
+[dir="rtl"] .blocks :global(.blocklyFlyout:hover) {
+    clip-path: inset(0 0 0 -100vw);
+    -webkit-clip-path: inset(0 0 0 -100vw);
+}
+
+.blocks :global(.blocklyFlyout:hover .blocklyWorkspace) {
+    clip-path: none;
+    -webkit-clip-path: none;
+}
+
+.blocks :global(.blocklyFlyout:hover .blocklyScrollbarBackground:hover) {
+    opacity: 0.4;
+}
+
+.blocks :global(.blocklyFlyout .blocklyFlyoutScrollbar) {
+    margin-left: 4px;
+}
+
 
 .blocks :global(.blocklyBlockDragSurface) {
     /*


### PR DESCRIPTION
## Summary
This PR implements a feature to show the full shape of long blocks in the Blockly flyout when the user hovers over them.

## Implementation Details
- Added CSS rules to `.blocks :global(.blocklyFlyout:hover)` to set `overflow: visible` and `clip-path`.
- Included `-webkit-clip-path` for better browser compatibility.
- Added RTL support using `[dir="rtl"]`.
- Removed clipping for `.blocklyWorkspace` on hover.
- Adjusted scrollbar opacity and margin to improve usability when the flyout expands.

This patch is based on the implementation from [xcratch/scratch-editor](https://github.com/xcratch/scratch-editor/commit/f4526cb5272cf4a9664f0d011e14d8033a8b1362).

## Test Coverage
- Verified that the CSS is correctly applied.
- Manual verification is required to confirm the visual behavior in the browser.

Fixes #19 (smalruby/smalruby3-develop)