### PR TITLE
feat: update scratch-vm dependency for lint warnings fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29135,7 +29135,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#fa7942a54cf715a3fd6048c8a7125e8c5ccca9c8",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#ce74dd03da27f7dcc5e040d76524b0756c2611e8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",


### PR DESCRIPTION
## Summary

- Update scratch-vm dependency to latest commit on develop branch
- Includes fix for format-message lint warnings

## Changes

Updated `package-lock.json` to reference the latest scratch-vm commit:
- Old: `fa7942a54cf715a3fd6048c8a7125e8c5ccca9c8`
- New: `ce74dd03da27f7dcc5e040d76524b0756c2611e8`

## Related

- smalruby/smalruby3-develop#21
- smalruby/scratch-vm#91

🤖 Generated with [Claude Code](https://claude.ai/code)
