### PR TITLE
feat: CI/CD ワークフローの2ジョブ並列実行への分割

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,50 @@ permissions:
     pull-requests: write # comment on released pull requests
 
 jobs:
-    ci-cd:
+    test:
+        runs-on: ubuntu-latest
+        if: |
+            (!(
+              github.ref == 'refs/heads/develop' ||
+              github.ref == 'refs/heads/master' ||
+              github.ref == 'refs/heads/main'
+            ))
+        env:
+            JEST_JUNIT_OUTPUT_DIR: test-results
+            NODE_OPTIONS: --max-old-space-size=4000
+        steps:
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - uses: actions/setup-node@26961cf329f22f6837d5f54c3efd76b480300ace # v4
+              with:
+                  cache: "npm"
+                  node-version-file: ".nvmrc"
+            - name: Info
+              run: |
+                  cat <<EOF
+                  Node version: $(node --version)
+                  NPM version: $(npm --version)
+                  GitHub ref: ${{ github.ref }}
+                  GitHub head ref: ${{ github.head_ref }}
+                  EOF
+            - name: Install Dependencies
+              run: npm ci
+            - name: Build scratch-vm for smalruby
+              run: npm run setup-scratch-vm
+            - name: Lint
+              run: npm run test:lint
+            - name: Run Unit Tests
+              env:
+                  JEST_JUNIT_OUTPUT_NAME: unit-results.xml
+                  JEST_JUNIT_OUTPUT_DIR: test-results/unit
+              run: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov --maxWorkers="2"
+            - name: Store Test Results
+              if: always() # Even if tests fail
+              uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+              with:
+                name: test-output-unit
+                path: ./test-results/*
+
+    build-and-deploy:
         runs-on: ubuntu-latest
         env:
             DETECT_CHROMEDRIVER_VERSION: "true"
@@ -40,25 +83,6 @@ jobs:
               run: npm ci
             - name: Build scratch-vm for smalruby
               run: npm run setup-scratch-vm
-            - name: Lint
-              if: |
-                (!(
-                  github.ref == 'refs/heads/develop' ||
-                  github.ref == 'refs/heads/master' ||
-                  github.ref == 'refs/heads/main'
-                ))
-              run: npm run test:lint
-            - name: Run Unit Tests
-              if: |
-                (!(
-                  github.ref == 'refs/heads/develop' ||
-                  github.ref == 'refs/heads/master' ||
-                  github.ref == 'refs/heads/main'
-                ))
-              env:
-                  JEST_JUNIT_OUTPUT_NAME: unit-results.xml
-                  JEST_JUNIT_OUTPUT_DIR: test-results/unit
-              run: npm run test:unit -- --reporters="default" --reporters="jest-junit" --coverage --coverageReporters=text --coverageReporters=lcov --maxWorkers="2"
             - name: Run Build
               env:
                 NODE_OPTIONS: --max-old-space-size=4000
@@ -105,8 +129,8 @@ jobs:
               if: always() # Even if tests fail
               uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
               with:
-                name: test-output
-                path: ./test-results/* # Both unit and integration test results
+                name: test-output-integration
+                path: ./test-results/*
             - run: |
                 if [[ ${{ contains(github.ref, 'hotfix') }} == 'true' ]]; then
                 sed -e "s|hotfix/REPLACE|${{ github.ref_name }}|" --in-place release.config.js


### PR DESCRIPTION
## Summary

CI/CD ワークフローの実行時間を短縮するため、単一ジョブを2つの並列ジョブに分割しました。

## Implementation Details

### Job 1: `test` (PR/feature branch のみ)
- Checkout → Setup Node → Install Dependencies → Build scratch-vm
- Lint
- Run Unit Tests
- Store Test Results (`test-output-unit`)

### Job 2: `build-and-deploy` (常に実行)
- Checkout → Setup Node → Install Dependencies → Build scratch-vm
- Run Build → Store Build/Dist Output
- Run Integration Tests (PR/feature branch のみ)
- Store Test Results (`test-output-integration`)
- Deploy steps (develop/master/main のみ)

### 並列実行イメージ

```
┌─────────────────────────────┐    ┌─────────────────────────────┐
│  Job: test                  │    │  Job: build-and-deploy      │
│  (PR/feature branchのみ)    │    │  (常に実行)                 │
└─────────────────────────────┘    └─────────────────────────────┘
         ↓ 並列実行 ↓                        ↓ 並列実行 ↓
```

## Test Coverage

- YAML構文検証済み
- CI実行により動作確認予定

## Expected Effect

- Lint + Unit Test と Build + Integration Test が並列実行される
- CI 全体の完了時間が短縮される

Fixes #519

🤖 Generated with [Claude Code](https://claude.ai/code)
