### PR TITLE
feat: add MicroBit More tilt/pin Ruby conversion (Issue #20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29135,7 +29135,7 @@
     },
     "node_modules/scratch-vm": {
       "version": "5.0.300",
-      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#ce74dd03da27f7dcc5e040d76524b0756c2611e8",
+      "resolved": "git+ssh://git@github.com/smalruby/scratch-vm.git#cc73cc0d84886c93c685205a8e3ea0e79832c71b",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@vernier/godirect": "^1.5.0",

--- a/src/containers/ruby-tab/microbit-more-snippets.json
+++ b/src/containers/ruby-tab/microbit-more-snippets.json
@@ -11,7 +11,7 @@
     },
     "microbit_more.button_pressed?": {
         "snippet": "microbit_more.button_pressed?(\"${1:A}\")",
-        "description": "ボタン [A▼] が押されている",
+        "description": "ボタン [A▼] が押された",
         "type": "value"
     },
     "microbit_more.when_pin_is": {
@@ -24,10 +24,25 @@
         "description": "ピン [ログ▼] がタッチされている",
         "type": "value"
     },
-    "microbit_more.when": {
-        "snippet": "microbit_more.when(\"${1:shake}\") do\n\t${2}\nend",
-        "description": "[ゆさぶられた▼] とき",
+    "microbit_more.when_pin_connected": {
+        "snippet": "microbit_more.when_pin_connected(${1:0}) do\n\t${2}\nend",
+        "description": "ピン [0▼] がつながったとき",
         "type": "event"
+    },
+    "microbit_more.when": {
+        "snippet": "microbit_more.when(\"${1:moved}\") do\n\t${2}\nend",
+        "description": "[動いた▼] とき",
+        "type": "event"
+    },
+    "microbit_more.tilted?": {
+        "snippet": "microbit_more.tilted?(\"${1:any}\")",
+        "description": "[どれかの向き▼] に傾いた",
+        "type": "value"
+    },
+    "microbit_more.tilt_angle": {
+        "snippet": "microbit_more.tilt_angle(\"${1:front}\")",
+        "description": "[前▼] 方向の傾き",
+        "type": "variable"
     },
     "microbit_more.display_pattern": {
         "snippet": "microbit_more.display_pattern(\n\t\"${1:.1.1.}\",\n\t\"${2:1.1.1}\",\n\t\"${3:1...1}\",\n\t\"${4:.1.1.}\",\n\t\"${5:..1..}\"\n)",

--- a/src/lib/ruby-generator/microbit_more.js
+++ b/src/lib/ruby-generator/microbit_more.js
@@ -40,24 +40,51 @@ export default function (Generator) {
         return [`microbit_more.pin_is_touched?(${name})`, Generator.ORDER_FUNCTION_CALL];
     };
 
+    Generator.microbitMore_whenPinConnected = function (block) {
+        block.isStatement = true;
+        const pin = Generator.getFieldValue(block, 'PIN', 'P0').replace('P', '');
+        return `microbit_more.when_pin_connected(${pin}) do\n`;
+    };
+
     const GestureLabel = {
-        TILT_UP: 'tilt up',
-        TILT_DOWN: 'tilt down',
-        TILT_LEFT: 'tilt left',
-        TILT_RIGHT: 'tilt right',
+        TILT_UP: 'tilted_front',
+        TILT_DOWN: 'tilted_back',
+        TILT_LEFT: 'tilted_left',
+        TILT_RIGHT: 'tilted_right',
         FACE_UP: 'face up',
         FACE_DOWN: 'face down',
         FREEFALL: 'freefall',
         G3: '3G',
         G6: '6G',
         G8: '8G',
-        SHAKE: 'shake'
+        SHAKE: 'shake',
+        MOVED: 'moved',
+        TILTED: 'tilted_any'
     };
     Generator.microbitMore_whenGesture = function (block) {
         block.isStatement = true;
         const gesture = Generator.getFieldValue(block, 'GESTURE', 'SHAKE');
         const gestureLabel = Generator.quote_(GestureLabel[gesture]);
         return `microbit_more.when(${gestureLabel}) do\n`;
+    };
+
+    const TiltedDirectionLabel = {
+        ANY: 'any',
+        TILT_UP: 'front',
+        TILT_DOWN: 'back',
+        TILT_LEFT: 'left',
+        TILT_RIGHT: 'right'
+    };
+    Generator.microbitMore_isTilted = function (block) {
+        const direction = Generator.getFieldValue(block, 'DIRECTION', 'ANY');
+        const directionLabel = Generator.quote_(TiltedDirectionLabel[direction]);
+        return [`microbit_more.tilted?(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
+    };
+
+    Generator.microbitMore_getTiltAngle = function (block) {
+        const direction = Generator.getFieldValue(block, 'DIRECTION', 'FRONT').toLowerCase();
+        const directionLabel = Generator.quote_(direction);
+        return [`microbit_more.tilt_angle(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     const makeMatrixArgs = function (matrix) {

--- a/src/lib/ruby-to-blocks-converter/microbit_more.js
+++ b/src/lib/ruby-to-blocks-converter/microbit_more.js
@@ -30,17 +30,19 @@ const TouchEventMenu = {
 };
 
 const GestureMenu = {
-    TILT_UP: 'tilt up',
-    TILT_DOWN: 'tilt down',
-    TILT_LEFT: 'tilt left',
-    TILT_RIGHT: 'tilt right',
+    TILT_UP: 'tilted_front',
+    TILT_DOWN: 'tilted_back',
+    TILT_LEFT: 'tilted_left',
+    TILT_RIGHT: 'tilted_right',
     FACE_UP: 'face up',
     FACE_DOWN: 'face down',
     FREEFALL: 'freefall',
     G3: '3G',
     G6: '6G',
     G8: '8G',
-    SHAKE: 'shake'
+    SHAKE: 'shake',
+    MOVED: 'moved',
+    TILTED: 'tilted_any'
 };
 const GestureMenuLower = Object.entries(GestureMenu).map(x => x[1].toLowerCase());
 const GestureMenuValue = Object.entries(GestureMenu).map(x => x[0]);
@@ -96,6 +98,32 @@ const ConnectionStateMenu = [
     'connected',
     'disconnected'
 ];
+
+const TouchPinIDMenu = {
+    0: 'P0',
+    1: 'P1',
+    2: 'P2'
+};
+const TouchPinIDMenuLower = Object.keys(TouchPinIDMenu);
+const TouchPinIDMenuValue = Object.values(TouchPinIDMenu);
+
+const TiltDirectionMenu = {
+    any: 'ANY',
+    front: 'TILT_UP',
+    back: 'TILT_DOWN',
+    left: 'TILT_LEFT',
+    right: 'TILT_RIGHT'
+};
+const TiltDirectionMenuLower = Object.keys(TiltDirectionMenu);
+const TiltDirectionMenuValue = Object.values(TiltDirectionMenu);
+
+const TiltAngleDirectionMenu = [
+    'FRONT',
+    'BACK',
+    'LEFT',
+    'RIGHT'
+];
+const TiltAngleDirectionMenuLower = TiltAngleDirectionMenu.map(x => x.toLowerCase());
 
 /**
  * MicrobitMore converter
@@ -228,6 +256,59 @@ const MicrobitMoreConverter = {
             const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenGesture', 'hat');
             converter.addField(block, 'GESTURE', args[0]);
             converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        converter.registerOnSendWithBlock(MicrobitMore, 'when_pin_connected', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isNumber(args[0])) {
+                const index = TouchPinIDMenuLower.indexOf(args[0].toString());
+                if (index < 0) return null;
+
+                args[0] = new Primitive('str', TouchPinIDMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenPinConnected', 'hat');
+            converter.addField(block, 'PIN', args[0]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        converter.registerOnSend(MicrobitMore, 'tilted?', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TiltDirectionMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+
+                args[0] = new Primitive('str', TiltDirectionMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block =
+                  converter.changeRubyExpressionBlock(receiver, 'microbitMore_isTilted', 'value_boolean');
+            converter.addField(block, 'DIRECTION', args[0]);
+            return block;
+        });
+
+        converter.registerOnSend(MicrobitMore, 'tilt_angle', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TiltAngleDirectionMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+
+                args[0] = new Primitive('str', TiltAngleDirectionMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getTiltAngle', 'value');
+            converter.addField(block, 'DIRECTION', args[0]);
             return block;
         });
 

--- a/src/locales/ja-Hira.js
+++ b/src/locales/ja-Hira.js
@@ -210,5 +210,11 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_mod': '(　) を (　) でわったあまり',
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) をししゃごにゅう',
     'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [ぜったいち▼]',
-    'gui.extensionLibrary.showAllExtensions': 'すべてのかくちょうきのうをひょうじ'
+    'gui.extensionLibrary.showAllExtensions': 'すべてのかくちょうきのうをひょうじ',
+
+    // MicroBit More - Tilt gesture labels (override to match microbit extension)
+    'mbitMore.gesturesMenu.tiltUp': 'うえにかたむいた',
+    'mbitMore.gesturesMenu.tiltDown': 'したにかたむいた',
+    'mbitMore.gesturesMenu.tiltLeft': 'ひだりにかたむいた',
+    'mbitMore.gesturesMenu.tiltRight': 'みぎにかたむいた'
 };

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -247,5 +247,11 @@ export default {
     'gui.smalruby3.blockDisplayModal.operator_mod': '(　) を (　) で割った余り',
     'gui.smalruby3.blockDisplayModal.operator_round': '(　) を四捨五入',
     'gui.smalruby3.blockDisplayModal.operator_mathop': '(　) の [絶対値▼]',
-    'gui.extensionLibrary.showAllExtensions': 'すべての拡張機能を表示'
+    'gui.extensionLibrary.showAllExtensions': 'すべての拡張機能を表示',
+
+    // MicroBit More - Tilt gesture labels (override to match microbit extension)
+    'mbitMore.gesturesMenu.tiltUp': '上に傾いた',
+    'mbitMore.gesturesMenu.tiltDown': '下に傾いた',
+    'mbitMore.gesturesMenu.tiltLeft': '左に傾いた',
+    'mbitMore.gesturesMenu.tiltRight': '右に傾いた'
 };

--- a/test/integration/ruby-tab/extension_microbit_more.test.js
+++ b/test/integration/ruby-tab/extension_microbit_more.test.js
@@ -51,6 +51,15 @@ describe('Ruby Tab: Microbit More v2 extension blocks', () => {
             microbit_more.when_pin_is("P2", "tapped") do
             end
 
+            microbit_more.when_pin_connected(0) do
+            end
+
+            microbit_more.when_pin_connected(1) do
+            end
+
+            microbit_more.when_pin_connected(2) do
+            end
+
             microbit_more.pin_is_touched?("LOGO")
 
             microbit_more.pin_is_touched?("P2")
@@ -60,6 +69,34 @@ describe('Ruby Tab: Microbit More v2 extension blocks', () => {
 
             microbit_more.when("6G") do
             end
+
+            microbit_more.when("moved") do
+            end
+
+            microbit_more.when("tilted_any") do
+            end
+
+            microbit_more.when("tilted_front") do
+            end
+
+            microbit_more.when("tilted_back") do
+            end
+
+            microbit_more.when("tilted_left") do
+            end
+
+            microbit_more.when("tilted_right") do
+            end
+
+            microbit_more.tilted?("any")
+
+            microbit_more.tilted?("front")
+
+            microbit_more.tilted?("back")
+
+            microbit_more.tilted?("left")
+
+            microbit_more.tilted?("right")
 
             microbit_more.display_pattern(
               ".1.1.",
@@ -88,6 +125,14 @@ describe('Ruby Tab: Microbit More v2 extension blocks', () => {
             microbit_more.pitch
 
             microbit_more.roll
+
+            microbit_more.tilt_angle("front")
+
+            microbit_more.tilt_angle("back")
+
+            microbit_more.tilt_angle("left")
+
+            microbit_more.tilt_angle("right")
 
             microbit_more.sound_level
 

--- a/test/unit/lib/ruby-generator/microbit_more.test.js
+++ b/test/unit/lib/ruby-generator/microbit_more.test.js
@@ -1,0 +1,90 @@
+import RubyGenerator from '../../../../src/lib/ruby-generator';
+import MicrobitMoreBlocks from '../../../../src/lib/ruby-generator/microbit_more';
+
+describe('RubyGenerator/MicrobitMore', () => {
+    beforeEach(() => {
+        RubyGenerator.cache_ = {};
+        RubyGenerator.definitions_ = {};
+        RubyGenerator.functionNames_ = {};
+        RubyGenerator.currentTarget = null;
+        MicrobitMoreBlocks(RubyGenerator);
+    });
+
+    test('microbitMore_whenPinConnected', () => {
+        const block = {
+            opcode: 'microbitMore_whenPinConnected',
+            fields: {
+                PIN: {
+                    value: 'P0'
+                }
+            }
+        };
+        const expected = 'microbit_more.when_pin_connected(0) do\n';
+        expect(RubyGenerator.microbitMore_whenPinConnected(block)).toEqual(expected);
+    });
+
+    test('microbitMore_isTilted', () => {
+        const block = {
+            opcode: 'microbitMore_isTilted',
+            fields: {
+                DIRECTION: {
+                    value: 'ANY'
+                }
+            }
+        };
+        const result = RubyGenerator.microbitMore_isTilted(block);
+        expect(result[0]).toEqual('microbit_more.tilted?("any")');
+    });
+
+    test('microbitMore_getTiltAngle', () => {
+        const block = {
+            opcode: 'microbitMore_getTiltAngle',
+            fields: {
+                DIRECTION: {
+                    value: 'FRONT'
+                }
+            }
+        };
+        const result = RubyGenerator.microbitMore_getTiltAngle(block);
+        expect(result[0]).toEqual('microbit_more.tilt_angle("front")');
+    });
+
+    test('microbitMore_whenGesture(MOVED)', () => {
+        const block = {
+            opcode: 'microbitMore_whenGesture',
+            fields: {
+                GESTURE: {
+                    value: 'MOVED'
+                }
+            }
+        };
+        const expected = 'microbit_more.when("moved") do\n';
+        expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
+    });
+
+    test('microbitMore_whenGesture(TILTED)', () => {
+        const block = {
+            opcode: 'microbitMore_whenGesture',
+            fields: {
+                GESTURE: {
+                    value: 'TILTED'
+                }
+            }
+        };
+        const expected = 'microbit_more.when("tilted_any") do\n';
+        expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
+    });
+
+    test('microbitMore_whenGesture(TILT_UP)', () => {
+        const block = {
+            opcode: 'microbitMore_whenGesture',
+            fields: {
+                GESTURE: {
+                    value: 'TILT_UP'
+                }
+            }
+        };
+        const expected = 'microbit_more.when("tilted_front") do\n';
+        expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
+    });
+});

--- a/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
+++ b/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
@@ -1,0 +1,118 @@
+import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
+import {
+    convertAndExpectToEqualBlocks,
+    rubyToExpected
+} from '../../../helpers/expect-to-equal-blocks';
+
+describe('RubyToBlocksConverter/MicrobitMore', () => {
+    let converter;
+    let target;
+    let code;
+    let expected;
+
+    beforeEach(() => {
+        converter = new RubyToBlocksConverter(null);
+        target = null;
+        code = null;
+        expected = null;
+    });
+
+    test('microbit_more.when_pin_connected', () => {
+        code = 'microbit_more.when_pin_connected(0) do; end';
+        expected = [
+            {
+                opcode: 'microbitMore_whenPinConnected',
+                fields: [
+                    {
+                        name: 'PIN',
+                        value: 'P0'
+                    }
+                ],
+                next: null,
+                parent: null,
+                topLevel: true
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.tilted?', () => {
+        code = 'microbit_more.tilted?("any")';
+        expected = [
+            {
+                opcode: 'microbitMore_isTilted',
+                fields: [
+                    {
+                        name: 'DIRECTION',
+                        value: 'ANY'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.tilt_angle', () => {
+        code = 'microbit_more.tilt_angle("front")';
+        expected = [
+            {
+                opcode: 'microbitMore_getTiltAngle',
+                fields: [
+                    {
+                        name: 'DIRECTION',
+                        value: 'FRONT'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.when(moved)', () => {
+        code = 'microbit_more.when("moved") do; end';
+        expected = [
+            {
+                opcode: 'microbitMore_whenGesture',
+                fields: [
+                    {
+                        name: 'GESTURE',
+                        value: 'MOVED'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.when(tilted_any)', () => {
+        code = 'microbit_more.when("tilted_any") do; end';
+        expected = [
+            {
+                opcode: 'microbitMore_whenGesture',
+                fields: [
+                    {
+                        name: 'GESTURE',
+                        value: 'TILTED'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.when(tilted_front)', () => {
+        code = 'microbit_more.when("tilted_front") do; end';
+        expected = [
+            {
+                opcode: 'microbitMore_whenGesture',
+                fields: [
+                    {
+                        name: 'GESTURE',
+                        value: 'TILT_UP'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+});


### PR DESCRIPTION
## Summary

MicroBit More拡張機能のIssue #20 に関する以下の実装を行いました：

1. 日本語ラベルの修正（前回のコミット）
2. 傾き・ピン接続ブロックとRubyの相互変換（今回のコミット）

## Implementation Details

### Task 3A: Label changes (previous commit)
- Changed tilt gesture labels from "へ傾いた" to "に傾いた" pattern
- Updated both `ja.js` and `ja-Hira.js` locale files

### Ruby Conversion (this commit)

#### Block to Ruby Conversions

| ブロック | Ruby |
|----------|------|
| ピン [0] がつながったとき | `microbit_more.when_pin_connected(0)` |
| [動いた] とき | `microbit_more.when("moved")` |
| [どれかの向きに傾いた] とき | `microbit_more.when("tilted_any")` |
| [前/後ろ/左/右に傾いた] とき | `microbit_more.when("tilted_front/back/left/right")` |
| [どれかの向き] に傾いた | `microbit_more.tilted?("any")` |
| [前] 方向の傾き | `microbit_more.tilt_angle("front")` |

#### Snippet Updates

- `microbit_more.button_pressed?`: description を「ボタン [A▼] が押された」に修正
- `microbit_more.when`: デフォルト値を "shake" → "moved" に変更、description を「[動いた▼] とき」に修正
- 新規追加: `when_pin_connected`, `tilted?`, `tilt_angle`

## Test Coverage

- Unit tests: `test/unit/lib/ruby-generator/microbit_more.test.js`
- Unit tests: `test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js`
- Integration test: `test/integration/ruby-tab/extension_microbit_more.test.js`

```bash
# Run tests
docker compose run --rm gui bash -c "cd /app/gui/smalruby3-gui && npm exec jest test/unit/lib/ruby-generator/microbit_more.test.js test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js"
docker compose run --rm gui bash -c "cd /app/gui/smalruby3-gui && npm run build && npm exec jest test/integration/ruby-tab/extension_microbit_more.test.js"
```

## Related

- smalruby/smalruby3-develop#20 (parent issue)
- smalruby/scratch-vm#92 (companion PR with new blocks)

Fixes smalruby/smalruby3-develop#20

🤖 Generated with [Claude Code](https://claude.ai/code)
