### PR TITLE
feat: add Ruby support for MicrobitMore display block

### DIFF
--- a/src/lib/ruby-generator/microbit_more.js
+++ b/src/lib/ruby-generator/microbit_more.js
@@ -111,6 +111,11 @@ export default function (Generator) {
         return `microbit_more.display_pattern(${matrix})\n`;
     };
 
+    Generator.microbitMore_display = function (block) {
+        const text = Generator.valueToCode(block, 'TEXT', Generator.ORDER_NONE) || Generator.quote_('Hello!');
+        return `microbit_more.display_text(${text})\n`;
+    };
+
     Generator.microbitMore_displayText = function (block) {
         const text = Generator.valueToCode(block, 'TEXT', Generator.ORDER_NONE) || Generator.quote_('Hello!');
         const delay = Generator.valueToCode(block, 'DELAY', Generator.ORDER_NONE) || 120;

--- a/src/lib/ruby-to-blocks-converter/microbit_more.js
+++ b/src/lib/ruby-to-blocks-converter/microbit_more.js
@@ -358,6 +358,16 @@ const MicrobitMoreConverter = {
             return block;
         });
 
+        converter.registerOnSend(MicrobitMore, 'display_text', 1, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_display', 'statement');
+            converter.addTextInput(block, 'TEXT', args[0], 'Hello!');
+            return block;
+        });
+
         converter.registerOnSend(MicrobitMore, 'display_text_delay', 2, params => {
             const {receiver, args} = params;
 

--- a/test/unit/lib/ruby-generator/microbit_more.test.js
+++ b/test/unit/lib/ruby-generator/microbit_more.test.js
@@ -100,4 +100,37 @@ describe('RubyGenerator/MicrobitMore', () => {
         const expected = 'microbit_more.when("tilted_front") do\n';
         expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
     });
+
+    test('microbitMore_display', () => {
+        const block = {
+            opcode: 'microbitMore_display',
+            inputs: {
+                TEXT: {
+                    name: 'TEXT'
+                }
+            }
+        };
+        RubyGenerator.valueToCode = jest.fn().mockReturnValue('"Hello!"');
+        const expected = 'microbit_more.display_text("Hello!")\n';
+        expect(RubyGenerator.microbitMore_display(block)).toEqual(expected);
+    });
+
+    test('microbitMore_displayText', () => {
+        const block = {
+            opcode: 'microbitMore_displayText',
+            inputs: {
+                TEXT: {
+                    name: 'TEXT'
+                },
+                DELAY: {
+                    name: 'DELAY'
+                }
+            }
+        };
+        RubyGenerator.valueToCode = jest.fn()
+            .mockReturnValueOnce('"Hello!"')
+            .mockReturnValueOnce('120');
+        const expected = 'microbit_more.display_text_delay("Hello!", 120)\n';
+        expect(RubyGenerator.microbitMore_displayText(block)).toEqual(expected);
+    });
 });

--- a/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
+++ b/test/unit/lib/ruby-to-blocks-converter/microbit_more.test.js
@@ -1,7 +1,8 @@
 import RubyToBlocksConverter from '../../../../src/lib/ruby-to-blocks-converter';
 import {
     convertAndExpectToEqualBlocks,
-    rubyToExpected
+    rubyToExpected,
+    expectedInfo
 } from '../../../helpers/expect-to-equal-blocks';
 
 describe('RubyToBlocksConverter/MicrobitMore', () => {
@@ -125,6 +126,42 @@ describe('RubyToBlocksConverter/MicrobitMore', () => {
                     {
                         name: 'GESTURE',
                         value: 'TILT_UP'
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.display_text', () => {
+        code = 'microbit_more.display_text("Hello!")';
+        expected = [
+            {
+                opcode: 'microbitMore_display',
+                inputs: [
+                    {
+                        name: 'TEXT',
+                        block: expectedInfo.makeText('Hello!')
+                    }
+                ]
+            }
+        ];
+        convertAndExpectToEqualBlocks(converter, target, code, expected);
+    });
+
+    test('microbit_more.display_text_delay', () => {
+        code = 'microbit_more.display_text_delay("Hello!", 120)';
+        expected = [
+            {
+                opcode: 'microbitMore_displayText',
+                inputs: [
+                    {
+                        name: 'TEXT',
+                        block: expectedInfo.makeText('Hello!')
+                    },
+                    {
+                        name: 'DELAY',
+                        block: expectedInfo.makeNumber(120)
                     }
                 ]
             }


### PR DESCRIPTION
## Summary
This PR adds Ruby support for the MicrobitMore "display" block, aligning its behavior with the standard Microbit extension.

## Changes
- Added `microbitMore_display` mapping in Ruby generator.
- Added `display_text` (1 argument) registration in Ruby to Blocks converter.
- Added unit tests for `microbitMore_display` and `microbitMore_displayText` in generator tests.
- Added unit tests for `microbit_more.display_text` and `microbit_more.display_text_delay` in converter tests.

## Verification
- Ran unit tests for both generator and converter.
- All tests passed.
- Lint passed.

Fixes #20 (partially, for MicrobitMore display block).