### PR TITLE
feat: change microbit receiver naming convention

### DIFF
--- a/src/containers/ruby-tab/microbit-more-snippets.json
+++ b/src/containers/ruby-tab/microbit-more-snippets.json
@@ -1,176 +1,176 @@
 {
-    "microbit_more.when_microbit": {
-        "snippet": "microbit_more.when_microbit(\"${1:connected}\") do\n\t${2}\nend",
+    "microbit.when_microbit": {
+        "snippet": "microbit.when_microbit(\"${1:connected}\") do\n\t${2}\nend",
         "description": "micro:bit と [つながった▼] とき",
         "type": "event"
     },
-    "microbit_more.when_button_is": {
-        "snippet": "microbit_more.when_button_is(\"${1:A}\", \"${2:down}\") do\n\t${3}\nend",
+    "microbit.when_button_is": {
+        "snippet": "microbit.when_button_is(\"${1:A}\", \"${2:down}\") do\n\t${3}\nend",
         "description": "ボタン [A▼] が [押された▼] とき",
         "type": "event"
     },
-    "microbit_more.button_pressed?": {
-        "snippet": "microbit_more.button_pressed?(\"${1:A}\")",
+    "microbit.button_pressed?": {
+        "snippet": "microbit.button_pressed?(\"${1:A}\")",
         "description": "ボタン [A▼] が押された",
         "type": "value"
     },
-    "microbit_more.when_pin_is": {
-        "snippet": "microbit_more.when_pin_is(\"${1:LOGO}\", \"${2:touched}\") do\n\t${3}\nend",
+    "microbit.when_pin_is": {
+        "snippet": "microbit.when_pin_is(\"${1:LOGO}\", \"${2:touched}\") do\n\t${3}\nend",
         "description": "ピン [ロゴ▼] が [タッチされた▼] とき",
         "type": "event"
     },
-    "microbit_more.pin_is_touched?": {
-        "snippet": "microbit_more.pin_is_touched?(\"${1:LOGO}\")",
+    "microbit.pin_is_touched?": {
+        "snippet": "microbit.pin_is_touched?(\"${1:LOGO}\")",
         "description": "ピン [ログ▼] がタッチされている",
         "type": "value"
     },
-    "microbit_more.when_pin_connected": {
-        "snippet": "microbit_more.when_pin_connected(${1:0}) do\n\t${2}\nend",
+    "microbit.when_pin_connected": {
+        "snippet": "microbit.when_pin_connected(${1:0}) do\n\t${2}\nend",
         "description": "ピン [0▼] がつながったとき",
         "type": "event"
     },
-    "microbit_more.when": {
-        "snippet": "microbit_more.when(\"${1:moved}\") do\n\t${2}\nend",
+    "microbit.when": {
+        "snippet": "microbit.when(\"${1:moved}\") do\n\t${2}\nend",
         "description": "[動いた▼] とき",
         "type": "event"
     },
-    "microbit_more.when_tilted": {
-        "snippet": "microbit_more.when_tilted(\"${1:any}\") do\n\t${2}\nend",
+    "microbit.when_tilted": {
+        "snippet": "microbit.when_tilted(\"${1:any}\") do\n\t${2}\nend",
         "description": "[どこか▼] に傾いたとき",
         "type": "event"
     },
-    "microbit_more.tilted?": {
-        "snippet": "microbit_more.tilted?(\"${1:any}\")",
+    "microbit.tilted?": {
+        "snippet": "microbit.tilted?(\"${1:any}\")",
         "description": "[どれかの向き▼] に傾いた",
         "type": "value"
     },
-    "microbit_more.tilt_angle": {
-        "snippet": "microbit_more.tilt_angle(\"${1:front}\")",
+    "microbit.tilt_angle": {
+        "snippet": "microbit.tilt_angle(\"${1:front}\")",
         "description": "[前▼] 方向の傾き",
         "type": "variable"
     },
-    "microbit_more.display_pattern": {
-        "snippet": "microbit_more.display_pattern(\n\t\"${1:.1.1.}\",\n\t\"${2:1.1.1}\",\n\t\"${3:1...1}\",\n\t\"${4:.1.1.}\",\n\t\"${5:..1..}\"\n)",
+    "microbit.display_pattern": {
+        "snippet": "microbit.display_pattern(\n\t\"${1:.1.1.}\",\n\t\"${2:1.1.1}\",\n\t\"${3:1...1}\",\n\t\"${4:.1.1.}\",\n\t\"${5:..1..}\"\n)",
         "description": "パターン (♡▼) を表示する",
         "type": "function"
     },
-    "microbit_more.display_text_delay": {
-        "snippet": "microbit_more.display_text_delay(\"${1:Hello!}\", ${2:120})",
+    "microbit.display_text_delay": {
+        "snippet": "microbit.display_text_delay(\"${1:Hello!}\", ${2:120})",
         "description": "文字 (Hello!) を (120) ミリ秒間隔で流す",
         "type": "function"
     },
-    "microbit_more.clear_display": {
-        "snippet": "microbit_more.clear_display",
+    "microbit.clear_display": {
+        "snippet": "microbit.clear_display",
         "description": "画面を消す",
         "type": "function"
     },
-    "microbit_more.light_intensity": {
-        "snippet": "microbit_more.light_intensity",
+    "microbit.light_intensity": {
+        "snippet": "microbit.light_intensity",
         "description": "明るさ",
         "type": "variable"
     },
-    "microbit_more.temperature": {
-        "snippet": "microbit_more.temperature",
+    "microbit.temperature": {
+        "snippet": "microbit.temperature",
         "description": "温度",
         "type": "variable"
     },
-    "microbit_more.angle_with_north": {
-        "snippet": "microbit_more.angle_with_north",
+    "microbit.angle_with_north": {
+        "snippet": "microbit.angle_with_north",
         "description": "北からの角度",
         "type": "variable"
     },
-    "microbit_more.pitch": {
-        "snippet": "microbit_more.pitch",
+    "microbit.pitch": {
+        "snippet": "microbit.pitch",
         "description": "ピッチ",
         "type": "variable"
     },
-    "microbit_more.roll": {
-        "snippet": "microbit_more.roll",
+    "microbit.roll": {
+        "snippet": "microbit.roll",
         "description": "ロール",
         "type": "variable"
     },
-    "microbit_more.sound_level": {
-        "snippet": "microbit_more.sound_level",
+    "microbit.sound_level": {
+        "snippet": "microbit.sound_level",
         "description": "音の大きさ",
         "type": "variable"
     },
-    "microbit_more.magnetic_force": {
-        "snippet": "microbit_more.magnetic_force(\"${1:absolute}\")",
+    "microbit.magnetic_force": {
+        "snippet": "microbit.magnetic_force(\"${1:absolute}\")",
         "description": "磁力 [大きさ▼]",
         "type": "variable"
     },
-    "microbit_more.acceleration": {
-        "snippet": "microbit_more.acceleration(\"${1:x}\")",
+    "microbit.acceleration": {
+        "snippet": "microbit.acceleration(\"${1:x}\")",
         "description": "加速度 [x▼]",
         "type": "variable"
     },
-    "microbit_more.analog_value": {
-        "snippet": "microbit_more.analog_value(\"${1:P0}\")",
+    "microbit.analog_value": {
+        "snippet": "microbit.analog_value(\"${1:P0}\")",
         "description": "ピン [P0▼] のアナログレベル",
         "type": "variable"
     },
-    "microbit_more.set_pin_to_input_pull": {
-        "snippet": "microbit_more.set_pin_to_input_pull(\"P0\", \"up\")",
+    "microbit.set_pin_to_input_pull": {
+        "snippet": "microbit.set_pin_to_input_pull(\"P0\", \"up\")",
         "description": "ピン [P0▼] を [プルアップ▼] 入力にする",
         "type": "function"
     },
-    "microbit_more.is_pin_high?": {
-        "snippet": "microbit_more.is_pin_high?(\"${1:P0}\")",
+    "microbit.is_pin_high?": {
+        "snippet": "microbit.is_pin_high?(\"${1:P0}\")",
         "description": "ピン [P0▼] がハイである",
         "type": "value"
     },
-    "microbit_more.set_digital": {
-        "snippet": "microbit_more.set_digital(\"${1:P0}\", \"${2:Low}\")",
+    "microbit.set_digital": {
+        "snippet": "microbit.set_digital(\"${1:P0}\", \"${2:Low}\")",
         "description": "ピン [P0▼] をデジタル出力 [ロー▼] にする",
         "type": "function"
     },
-    "microbit_more.set_analog": {
-        "snippet": "microbit_more.set_analog(\"${1:P0}\", ${2:0})",
+    "microbit.set_analog": {
+        "snippet": "microbit.set_analog(\"${1:P0}\", ${2:0})",
         "description": "ピン [P0▼] をアナログ出力 [LEVEL] %にする",
         "type": "function"
     },
-    "microbit_more.set_servo": {
-        "snippet": "microbit_more.set_servo(\"${1:P0}\", ${2:0})",
+    "microbit.set_servo": {
+        "snippet": "microbit.set_servo(\"${1:P0}\", ${2:0})",
         "description": "ピン [P0▼] をサーボ (0) 度にする",
         "type": "function"
     },
-    "microbit_more.play_tone": {
-        "snippet": "microbit_more.play_tone(${1:440}, ${2:100})",
+    "microbit.play_tone": {
+        "snippet": "microbit.play_tone(${1:440}, ${2:100})",
         "description": "(440) Hzの音を (100) %の大きさで鳴らす",
         "type": "function"
     },
-    "microbit_more.stop_tone": {
-        "snippet": "microbit_more.stop_tone",
+    "microbit.stop_tone": {
+        "snippet": "microbit.stop_tone",
         "description": "音を止める",
         "type": "function"
     },
-    "microbit_more.listen_event_on": {
-        "snippet": "microbit_more.listen_event_on(\"${1:none}\", \"${2:P0}\")",
+    "microbit.listen_event_on": {
+        "snippet": "microbit.listen_event_on(\"${1:none}\", \"${2:P0}\")",
         "description": "ピン [P0▼] の [イベントを受けない▼]",
         "type": "function"
     },
-    "microbit_more.when_catch_at_pin": {
-        "snippet": "microbit_more.when_catch_at_pin(\"${1:low pulse}\", \"${2:P0}\") do\n\t${3}\nend",
+    "microbit.when_catch_at_pin": {
+        "snippet": "microbit.when_catch_at_pin(\"${1:low pulse}\", \"${2:P0}\") do\n\t${3}\nend",
         "description": "ピン [P0▼] で [ローパルス▼] イベントが起きたとき",
         "type": "event"
     },
-    "microbit_more.value_of": {
-        "snippet": "microbit_more.value_of(\"${1:low pulse}\", \"${2:P0}\")",
+    "microbit.value_of": {
+        "snippet": "microbit.value_of(\"${1:low pulse}\", \"${2:P0}\")",
         "description": "ピン [P0▼] の [ローパルスの期間▼]",
         "type": "function"
     },
-    "microbit_more.when_data_received_from_microbit": {
-        "snippet": "microbit_more.when_data_received_from_microbit(\"${1:label-01}\") do\n\t${2}\nend",
+    "microbit.when_data_received_from_microbit": {
+        "snippet": "microbit.when_data_received_from_microbit(\"${1:label-01}\") do\n\t${2}\nend",
         "description": "micro:bit からラベル (label-01) のデータを受け取ったとき",
         "type": "event"
     },
-    "microbit_more.data": {
-        "snippet": "microbit_more.data[\"${1:label-01}\"]",
+    "microbit.data": {
+        "snippet": "microbit.data[\"${1:label-01}\"]",
         "description": "ラベル (label-01) のデータ",
         "type": "variable"
     },
-    "microbit_more.send_data_to_microbit": {
-        "snippet": "microbit_more.send_data_to_microbit(\"${1:data}\", \"${2:label-01}\")",
+    "microbit.send_data_to_microbit": {
+        "snippet": "microbit.send_data_to_microbit(\"${1:data}\", \"${2:label-01}\")",
         "description": "micro:bit へデータ (data) にラベル (label-01) を付けて送る",
         "type": "function"
     }

--- a/src/containers/ruby-tab/microbit-snippets.json
+++ b/src/containers/ruby-tab/microbit-snippets.json
@@ -1,46 +1,46 @@
 {
-    "microbit.when_button_pressed": {
-        "snippet": "microbit.when_button_pressed(\"${1:A}\") do\n\t${2}\nend",
+    "microbit_v1.when_button_pressed": {
+        "snippet": "microbit_v1.when_button_pressed(\"${1:A}\") do\n\t${2}\nend",
         "description": "ボタン (A▼) が押されたとき",
         "type": "event"
     },
-    "microbit.button_pressed?": {
-        "snippet": "microbit.button_pressed?(\"${1:A}\")",
+    "microbit_v1.button_pressed?": {
+        "snippet": "microbit_v1.button_pressed?(\"${1:A}\")",
         "description": "ボタン (A▼) が押された",
         "type": "function"
     },
-    "microbit.when": {
-        "snippet": "microbit.when(\"${1:moved}\") do\n\t${2}\nend",
+    "microbit_v1.when": {
+        "snippet": "microbit_v1.when(\"${1:moved}\") do\n\t${2}\nend",
         "description": "(動いた▼) とき",
         "type": "event"
     },
-    "microbit.display_text": {
-        "snippet": "microbit.display_text(\"${1:こんにちは!}\")",
+    "microbit_v1.display_text": {
+        "snippet": "microbit_v1.display_text(\"${1:こんにちは!}\")",
         "description": "(こんにちは!) を表示する",
         "type": "function"
     },
-    "microbit.display": {
-        "snippet": "microbit.display(\n  \"${1:.1.1.}\",\n  \"${2:1.1.1}\",\n  \"${3:1...1}\",\n  \"${4:.1.1.}\",\n  \"${5:..1..}\"\n)",
+    "microbit_v1.display": {
+        "snippet": "microbit_v1.display(\n  \"${1:.1.1.}\",\n  \"${2:1.1.1}\",\n  \"${3:1...1}\",\n  \"${4:.1.1.}\",\n  \"${5:..1..}\"\n)",
         "description": "(♡▼) を表示する",
         "type": "function"
     },
-    "microbit.when_tilted": {
-        "snippet": "microbit.when_tilted(\"${1:any}\") do\n\t${2}\nend",
+    "microbit_v1.when_tilted": {
+        "snippet": "microbit_v1.when_tilted(\"${1:any}\") do\n\t${2}\nend",
         "description": "(どれかの向き▼) に傾いたとき",
         "type": "event"
     },
-    "microbit.tilted?": {
-        "snippet": "microbit.tilted?(\"${1:any}\")",
+    "microbit_v1.tilted?": {
+        "snippet": "microbit_v1.tilted?(\"${1:any}\")",
         "description": "(どれかの向き▼) に傾いた",
         "type": "value"
     },
-    "microbit.tilt_angle": {
-        "snippet": "microbit.tilt_angle(\"${1:front}\")",
+    "microbit_v1.tilt_angle": {
+        "snippet": "microbit_v1.tilt_angle(\"${1:front}\")",
         "description": "(前▼) 方向の傾き",
         "type": "variable"
     },
-    "microbit.when_pin_connected": {
-        "snippet": "microbit.when_pin_connected(${1:0}) do\n\t${2}\nend",
+    "microbit_v1.when_pin_connected": {
+        "snippet": "microbit_v1.when_pin_connected(${1:0}) do\n\t${2}\nend",
         "description": "ピン (0▼) がつながったとき",
         "type": "event"
     }

--- a/src/lib/ruby-generator/microbit.js
+++ b/src/lib/ruby-generator/microbit.js
@@ -7,18 +7,18 @@ export default function (Generator) {
     Generator.microbit_whenButtonPressed = function (block) {
         block.isStatement = true;
         const btn = Generator.valueToCode(block, 'BTN', Generator.ORDER_NONE) || null;
-        return `microbit.when_button_pressed(${btn}) do\n`;
+        return `microbit_v1.when_button_pressed(${btn}) do\n`;
     };
 
     Generator.microbit_isButtonPressed = function (block) {
         const btn = Generator.valueToCode(block, 'BTN', Generator.ORDER_NONE) || null;
-        return `microbit.button_pressed?(${btn})\n`;
+        return `microbit_v1.button_pressed?(${btn})\n`;
     };
 
     Generator.microbit_whenGesture = function (block) {
         block.isStatement = true;
         const gesture = Generator.valueToCode(block, 'GESTURE', Generator.ORDER_NONE) || null;
-        return `microbit.when(${gesture}) do\n`;
+        return `microbit_v1.when(${gesture}) do\n`;
     };
 
     Generator.microbit_displaySymbol = function (block) {
@@ -26,38 +26,38 @@ export default function (Generator) {
         if (matrix.indexOf('\n') >= 0) {
             matrix = `\n${Generator.prefixLines(matrix, Generator.INDENT)}\n`;
         }
-        return `microbit.display(${matrix})\n`;
+        return `microbit_v1.display(${matrix})\n`;
     };
 
     Generator.microbit_displayText = function (block) {
         const text = Generator.valueToCode(block, 'TEXT', Generator.ORDER_NONE) || null;
-        return `microbit.display_text(${text})\n`;
+        return `microbit_v1.display_text(${text})\n`;
     };
 
     Generator.microbit_displayClear = function () {
-        return `microbit.clear_display\n`;
+        return `microbit_v1.clear_display\n`;
     };
 
     Generator.microbit_whenTilted = function (block) {
         block.isStatement = true;
         const direction = Generator.valueToCode(block, 'DIRECTION', Generator.ORDER_NONE) || null;
-        return `microbit.when_tilted(${direction}) do\n`;
+        return `microbit_v1.when_tilted(${direction}) do\n`;
     };
 
     Generator.microbit_isTilted = function (block) {
         const direction = Generator.valueToCode(block, 'DIRECTION', Generator.ORDER_NONE) || null;
-        return [`microbit.tilted?(${direction})`, Generator.ORDER_ATOMIC];
+        return [`microbit_v1.tilted?(${direction})`, Generator.ORDER_ATOMIC];
     };
 
     Generator.microbit_getTiltAngle = function (block) {
         const direction = Generator.valueToCode(block, 'DIRECTION', Generator.ORDER_NONE) || null;
-        return [`microbit.tilt_angle(${direction})`, Generator.ORDER_ATOMIC];
+        return [`microbit_v1.tilt_angle(${direction})`, Generator.ORDER_ATOMIC];
     };
 
     Generator.microbit_whenPinConnected = function (block) {
         block.isStatement = true;
         const pin = Generator.valueToCode(block, 'PIN', Generator.ORDER_NONE) || null;
-        return `microbit.when_pin_connected(${pin}) do\n`;
+        return `microbit_v1.when_pin_connected(${pin}) do\n`;
     };
 
     Generator.microbit_menu_buttons = function (block) {

--- a/src/lib/ruby-generator/microbit_more.js
+++ b/src/lib/ruby-generator/microbit_more.js
@@ -7,19 +7,19 @@ export default function (Generator) {
     Generator.microbitMore_whenConnectionChanged = function (block) {
         block.isStatement = true;
         const state = Generator.quote_(Generator.getFieldValue(block, 'STATE', 'connected'));
-        return `microbit_more.when_microbit(${state}) do\n`;
+        return `microbit.when_microbit(${state}) do\n`;
     };
 
     Generator.microbitMore_whenButtonEvent = function (block) {
         block.isStatement = true;
         const name = Generator.quote_(Generator.getFieldValue(block, 'NAME', 'A'));
         const event = Generator.quote_(Generator.getFieldValue(block, 'EVENT', 'down').toLowerCase());
-        return `microbit_more.when_button_is(${name}, ${event}) do\n`;
+        return `microbit.when_button_is(${name}, ${event}) do\n`;
     };
 
     Generator.microbitMore_isButtonPressed = function (block) {
         const name = Generator.quote_(Generator.getFieldValue(block, 'NAME', 'A'));
-        return [`microbit_more.button_pressed?(${name})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.button_pressed?(${name})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     const TouchEventLabel = {
@@ -32,18 +32,18 @@ export default function (Generator) {
         const name = Generator.quote_(Generator.getFieldValue(block, 'NAME', 'LOGO'));
         const event = Generator.getFieldValue(block, 'EVENT', 'DOWN');
         const eventLabel = Generator.quote_(TouchEventLabel[event]);
-        return `microbit_more.when_pin_is(${name}, ${eventLabel}) do\n`;
+        return `microbit.when_pin_is(${name}, ${eventLabel}) do\n`;
     };
 
     Generator.microbitMore_isPinTouched = function (block) {
         const name = Generator.quote_(Generator.getFieldValue(block, 'NAME', 'LOGO'));
-        return [`microbit_more.pin_is_touched?(${name})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.pin_is_touched?(${name})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_whenPinConnected = function (block) {
         block.isStatement = true;
         const pin = Generator.getFieldValue(block, 'PIN', 'P0').replace('P', '');
-        return `microbit_more.when_pin_connected(${pin}) do\n`;
+        return `microbit.when_pin_connected(${pin}) do\n`;
     };
 
     Generator.microbitMore_whenGesture = function (block) {
@@ -66,7 +66,7 @@ export default function (Generator) {
         };
         const gesture = Generator.getFieldValue(block, 'GESTURE', 'SHAKE');
         const gestureLabel = Generator.quote_(GestureLabel[gesture]);
-        return `microbit_more.when(${gestureLabel}) do\n`;
+        return `microbit.when(${gestureLabel}) do\n`;
     };
 
     const TiltedDirectionLabel = {
@@ -80,19 +80,19 @@ export default function (Generator) {
         block.isStatement = true;
         const direction = Generator.getFieldValue(block, 'DIRECTION', 'ANY');
         const directionLabel = Generator.quote_(TiltedDirectionLabel[direction] || direction);
-        return `microbit_more.when_tilted(${directionLabel}) do\n`;
+        return `microbit.when_tilted(${directionLabel}) do\n`;
     };
 
     Generator.microbitMore_isTilted = function (block) {
         const direction = Generator.getFieldValue(block, 'DIRECTION', 'ANY');
         const directionLabel = Generator.quote_(TiltedDirectionLabel[direction] || direction);
-        return [`microbit_more.tilted?(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.tilted?(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getTiltAngle = function (block) {
         const direction = Generator.getFieldValue(block, 'DIRECTION', 'FRONT').toLowerCase();
         const directionLabel = Generator.quote_(direction);
-        return [`microbit_more.tilt_angle(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.tilt_angle(${directionLabel})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     const makeMatrixArgs = function (matrix) {
@@ -108,100 +108,100 @@ export default function (Generator) {
         if (matrix.indexOf('\n') >= 0) {
             matrix = `\n${Generator.prefixLines(matrix, Generator.INDENT)}\n`;
         }
-        return `microbit_more.display_pattern(${matrix})\n`;
+        return `microbit.display_pattern(${matrix})\n`;
     };
 
     Generator.microbitMore_display = function (block) {
         const text = Generator.valueToCode(block, 'TEXT', Generator.ORDER_NONE) || Generator.quote_('Hello!');
-        return `microbit_more.display_text(${text})\n`;
+        return `microbit.display_text(${text})\n`;
     };
 
     Generator.microbitMore_displayText = function (block) {
         const text = Generator.valueToCode(block, 'TEXT', Generator.ORDER_NONE) || Generator.quote_('Hello!');
         const delay = Generator.valueToCode(block, 'DELAY', Generator.ORDER_NONE) || 120;
-        return `microbit_more.display_text_delay(${text}, ${delay})\n`;
+        return `microbit.display_text_delay(${text}, ${delay})\n`;
     };
 
     Generator.microbitMore_displayClear = function () {
-        return `microbit_more.clear_display\n`;
+        return `microbit.clear_display\n`;
     };
 
     Generator.microbitMore_getLightLevel = function () {
-        return ['microbit_more.light_intensity', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.light_intensity', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getTemperature = function () {
-        return ['microbit_more.temperature', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.temperature', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getCompassHeading = function () {
-        return ['microbit_more.angle_with_north', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.angle_with_north', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getPitch = function () {
-        return ['microbit_more.pitch', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.pitch', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getRoll = function () {
-        return ['microbit_more.roll', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.roll', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getSoundLevel = function () {
-        return ['microbit_more.sound_level', Generator.ORDER_FUNCTION_CALL];
+        return ['microbit.sound_level', Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getMagneticForce = function (block) {
         const axis = Generator.quote_(Generator.getFieldValue(block, 'AXIS', 'absolute'));
-        return [`microbit_more.magnetic_force(${axis})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.magnetic_force(${axis})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getAcceleration = function (block) {
         const axis = Generator.quote_(Generator.getFieldValue(block, 'AXIS', 'x'));
-        return [`microbit_more.acceleration(${axis})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.acceleration(${axis})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_getAnalogValue = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
-        return [`microbit_more.analog_value(${pin})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.analog_value(${pin})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_setPullMode = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
         const mode = Generator.quote_(Generator.getFieldValue(block, 'MODE', 'up').toLowerCase());
-        return `microbit_more.set_pin_to_input_pull(${pin}, ${mode})\n`;
+        return `microbit.set_pin_to_input_pull(${pin}, ${mode})\n`;
     };
 
     Generator.microbitMore_isPinHigh = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
-        return [`microbit_more.is_pin_high?(${pin})`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.is_pin_high?(${pin})`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_setDigitalOut = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
         const level = Generator.valueToCode(block, 'LEVEL', Generator.ORDER_NONE) || Generator.quote_('Low');
-        return `microbit_more.set_digital(${pin}, ${level})\n`;
+        return `microbit.set_digital(${pin}, ${level})\n`;
     };
 
     Generator.microbitMore_setAnalogOut = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
         const level = Generator.valueToCode(block, 'LEVEL', Generator.ORDER_NONE) || 0;
-        return `microbit_more.set_analog(${pin}, ${level})\n`;
+        return `microbit.set_analog(${pin}, ${level})\n`;
     };
 
     Generator.microbitMore_setServo = function (block) {
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
         const angle = Generator.valueToCode(block, 'ANGLE', Generator.ORDER_NONE) || 0;
-        return `microbit_more.set_servo(${pin}, ${angle})\n`;
+        return `microbit.set_servo(${pin}, ${angle})\n`;
     };
 
     Generator.microbitMore_playTone = function (block) {
         const freq = Generator.valueToCode(block, 'FREQ', Generator.ORDER_NONE) || 440;
         const vol = Generator.valueToCode(block, 'VOL', Generator.ORDER_NONE) || 100;
-        return `microbit_more.play_tone(${freq}, ${vol})\n`;
+        return `microbit.play_tone(${freq}, ${vol})\n`;
     };
 
     Generator.microbitMore_stopTone = function () {
-        return `microbit_more.stop_tone\n`;
+        return `microbit.stop_tone\n`;
     };
 
     const EventTypeLabel = {
@@ -213,7 +213,7 @@ export default function (Generator) {
         const eventType = Generator.getFieldValue(block, 'EVENT_TYPE', 'NONE');
         const eventTypeLabel = Generator.quote_(EventTypeLabel[eventType]);
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
-        return `microbit_more.listen_event_on(${eventTypeLabel}, ${pin})\n`;
+        return `microbit.listen_event_on(${eventTypeLabel}, ${pin})\n`;
     };
 
     const EventLabel = {
@@ -227,31 +227,31 @@ export default function (Generator) {
         const event = Generator.getFieldValue(block, 'EVENT', 'PULSE_LOW');
         const eventLabel = Generator.quote_(EventLabel[event]);
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
-        return `microbit_more.when_catch_at_pin(${eventLabel}, ${pin}) do\n`;
+        return `microbit.when_catch_at_pin(${eventLabel}, ${pin}) do\n`;
     };
 
     Generator.microbitMore_getPinEventValue = function (block) {
         const event = Generator.getFieldValue(block, 'EVENT', 'PULSE_LOW');
         const eventLabel = Generator.quote_(EventLabel[event]);
         const pin = Generator.quote_(`P${Generator.getFieldValue(block, 'PIN', '0')}`);
-        return `microbit_more.value_of(${eventLabel}, ${pin})\n`;
+        return `microbit.value_of(${eventLabel}, ${pin})\n`;
     };
 
     Generator.microbitMore_whenDataReceived = function (block) {
         block.isStatement = true;
         const label = Generator.valueToCode(block, 'LABEL', Generator.ORDER_NONE) || Generator.quote_('label-01');
-        return `microbit_more.when_data_received_from_microbit(${label}) do\n`;
+        return `microbit.when_data_received_from_microbit(${label}) do\n`;
     };
 
     Generator.microbitMore_getDataLabeled = function (block) {
         const label = Generator.valueToCode(block, 'LABEL', Generator.ORDER_NONE) || Generator.quote_('label-01');
-        return [`microbit_more.data[${label}]`, Generator.ORDER_FUNCTION_CALL];
+        return [`microbit.data[${label}]`, Generator.ORDER_FUNCTION_CALL];
     };
 
     Generator.microbitMore_sendData = function (block) {
         const label = Generator.valueToCode(block, 'LABEL', Generator.ORDER_NONE) || Generator.quote_('label-01');
         const data = Generator.valueToCode(block, 'DATA', Generator.ORDER_NONE) || Generator.quote_('data');
-        return `microbit_more.send_data_to_microbit(${data}, ${label})\n`;
+        return `microbit.send_data_to_microbit(${data}, ${label})\n`;
     };
 
     Generator.microbitMore_menu_digitalValueMenu = function (block) {

--- a/src/lib/ruby-to-blocks-converter/microbit.js
+++ b/src/lib/ruby-to-blocks-converter/microbit.js
@@ -1,6 +1,6 @@
 import Primitive from './primitive';
 
-const MicroBit = 'microbit';
+const MicroBit = 'microbit_v1';
 
 const ButtonsMenu = [
     'A',

--- a/src/lib/ruby-to-blocks-converter/microbit_more.js
+++ b/src/lib/ruby-to-blocks-converter/microbit_more.js
@@ -1,7 +1,9 @@
 import Primitive from './primitive';
 
-const MicrobitMore = 'microbit_more';
-const MicrobitMoreData = 'microbit_more.data';
+const MicrobitMore = 'microbit';
+const MicrobitMoreLegacy = 'microbit_more'; // backward compatibility
+const MicrobitMoreData = 'microbit.data';
+const MicrobitMoreDataLegacy = 'microbit_more.data'; // backward compatibility
 
 const ButtonIDMenu = [
     'A',
@@ -713,6 +715,609 @@ const MicrobitMoreConverter = {
         });
 
         converter.registerOnSend(MicrobitMore, 'send_data_to_microbit', 2, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+            if (!converter.isStringOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_sendData', 'statement');
+            converter.addTextInput(block, 'LABEL', args[1], 'label-01');
+            converter.addTextInput(block, 'DATA', args[0], 'data');
+            return block;
+        });
+
+        // backward compatibility: register 'microbit_more' as an alias for 'microbit'
+        converter.registerOnSend('self', MicrobitMoreLegacy, 0, params => {
+            const {node} = params;
+            return converter.createRubyExpressionBlock(MicrobitMoreLegacy, node);
+        });
+
+        // Helper function to register backward compatibility handlers
+        const registerLegacyHandler = (method, numArgs, handler) => {
+            converter.registerOnSend(MicrobitMoreLegacy, method, numArgs, handler);
+        };
+        const registerLegacyHandlerWithBlock = (method, numArgs, numBlockArgs, handler) => {
+            converter.registerOnSendWithBlock(MicrobitMoreLegacy, method, numArgs, numBlockArgs, handler);
+        };
+
+        // backward compatibility: when_microbit
+        registerLegacyHandlerWithBlock('when_microbit', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (!converter.isString(args[0])) return null;
+            const index = ConnectionStateMenu.indexOf(args[0].toString().toLowerCase());
+            if (index < 0) return null;
+            args[0] = new Primitive('str', ConnectionStateMenu[index], args[0].node);
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenConnectionChanged', 'hat');
+            converter.addField(block, 'STATE', args[0]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: when_button_is
+        registerLegacyHandlerWithBlock('when_button_is', 2, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isString(args[0])) {
+                const index = ButtonIDMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', ButtonIDMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+            if (converter.isString(args[1])) {
+                const index = ButtonEventMenu.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('str', ButtonEventMenu[index], args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenButtonEvent', 'hat');
+            converter.addField(block, 'NAME', args[0]);
+            converter.addField(block, 'EVENT', args[1]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: button_pressed?
+        registerLegacyHandler('button_pressed?', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = ButtonIDMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', ButtonIDMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block =
+                  converter.changeRubyExpressionBlock(receiver, 'microbitMore_isButtonPressed', 'value_boolean');
+            converter.addField(block, 'NAME', args[0]);
+            return block;
+        });
+
+        // backward compatibility: when_pin_is
+        registerLegacyHandlerWithBlock('when_pin_is', 2, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TouchIDMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TouchIDMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            if (converter.isString(args[1])) {
+                const event = TouchEventMenu[args[1].toString().toLowerCase()];
+                if (!event) return null;
+                args[1] = new Primitive('str', event, args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenTouchEvent', 'hat');
+            converter.addField(block, 'NAME', args[0]);
+            converter.addField(block, 'EVENT', args[1]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: pin_is_touched?
+        registerLegacyHandler('pin_is_touched?', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TouchIDMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TouchIDMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block =
+                  converter.changeRubyExpressionBlock(receiver, 'microbitMore_isPinTouched', 'value_boolean');
+            converter.addField(block, 'NAME', args[0]);
+            return block;
+        });
+
+        // backward compatibility: when (gesture)
+        registerLegacyHandlerWithBlock('when', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GestureMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', GestureMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenGesture', 'hat');
+            converter.addField(block, 'GESTURE', args[0]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: when_tilted
+        registerLegacyHandlerWithBlock('when_tilted', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TiltDirectionMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TiltDirectionMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenTilted', 'hat');
+            converter.addField(block, 'DIRECTION', args[0]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: when_pin_connected
+        registerLegacyHandlerWithBlock('when_pin_connected', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isNumber(args[0])) {
+                const index = TouchPinIDMenuLower.indexOf(args[0].toString());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TouchPinIDMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenPinConnected', 'hat');
+            converter.addField(block, 'PIN', args[0]);
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: tilted?
+        registerLegacyHandler('tilted?', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TiltDirectionMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TiltDirectionMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block =
+                  converter.changeRubyExpressionBlock(receiver, 'microbitMore_isTilted', 'value_boolean');
+            converter.addField(block, 'DIRECTION', args[0]);
+            return block;
+        });
+
+        // backward compatibility: tilt_angle
+        registerLegacyHandler('tilt_angle', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = TiltAngleDirectionMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', TiltAngleDirectionMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getTiltAngle', 'value');
+            converter.addField(block, 'DIRECTION', args[0]);
+            return block;
+        });
+
+        // backward compatibility: display_pattern (5 args)
+        registerLegacyHandler('display_pattern', 5, params => {
+            const {receiver, args} = params;
+
+            if (!args.every(x => converter.isString(x))) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_displayMatrix', 'statement');
+
+            let matrix = '';
+            for (const arg of args) {
+                matrix += arg;
+            }
+            matrix = matrix.replace(/[1-9]/g, '1').replace(/[^1-9]/g, '0');
+            converter.addFieldInput(block, 'MATRIX', 'matrix', 'MATRIX', matrix, null);
+            return block;
+        });
+
+        // backward compatibility: display_pattern (1 arg)
+        registerLegacyHandler('display_pattern', 1, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_displayMatrix', 'statement');
+            converter.addFieldInput(block, 'MATRIX', 'matrix', 'MATRIX', args[0], '0101010101100010101000100');
+            return block;
+        });
+
+        // backward compatibility: display_text
+        registerLegacyHandler('display_text', 1, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_display', 'statement');
+            converter.addTextInput(block, 'TEXT', args[0], 'Hello!');
+            return block;
+        });
+
+        // backward compatibility: display_text_delay
+        registerLegacyHandler('display_text_delay', 2, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+            if (!converter.isNumberOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_displayText', 'statement');
+            converter.addTextInput(block, 'TEXT', args[0], 'Hello!');
+            converter.addNumberInput(block, 'DELAY', 'math_number', args[1], 120);
+            return block;
+        });
+
+        // backward compatibility: clear_display
+        registerLegacyHandler('clear_display', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_displayClear', 'statement');
+        });
+
+        // backward compatibility: light_intensity
+        registerLegacyHandler('light_intensity', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getLightLevel', 'value');
+        });
+
+        // backward compatibility: temperature
+        registerLegacyHandler('temperature', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getTemperature', 'value');
+        });
+
+        // backward compatibility: angle_with_north
+        registerLegacyHandler('angle_with_north', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getCompassHeading', 'value');
+        });
+
+        // backward compatibility: pitch
+        registerLegacyHandler('pitch', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getPitch', 'value');
+        });
+
+        // backward compatibility: roll
+        registerLegacyHandler('roll', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getRoll', 'value');
+        });
+
+        // backward compatibility: sound_level
+        registerLegacyHandler('sound_level', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_getSoundLevel', 'value');
+        });
+
+        // backward compatibility: magnetic_force
+        registerLegacyHandler('magnetic_force', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = AccelerationMenu.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', AccelerationMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getMagneticForce', 'value');
+            converter.addField(block, 'AXIS', args[0]);
+            return block;
+        });
+
+        // backward compatibility: acceleration
+        registerLegacyHandler('acceleration', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = AccelerationMenu.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', AccelerationMenu[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getAcceleration', 'value');
+            converter.addField(block, 'AXIS', args[0]);
+            return block;
+        });
+
+        // backward compatibility: analog_value
+        registerLegacyHandler('analog_value', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = AnalogInPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', AnalogIn[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getAnalogValue', 'value');
+            converter.addField(block, 'PIN', args[0]);
+            return block;
+        });
+
+        // backward compatibility: set_pin_to_input_pull
+        registerLegacyHandler('set_pin_to_input_pull', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GpioPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', Gpio[index], args[0].node);
+            } else {
+                return null;
+            }
+            if (converter.isString(args[1])) {
+                const index = PinModeMenuLower.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('str', PinModeMenu[index], args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_setPullMode', 'statement');
+            converter.addField(block, 'PIN', args[0]);
+            converter.addField(block, 'MODE', args[1]);
+            return block;
+        });
+
+        // backward compatibility: is_pin_high?
+        registerLegacyHandler('is_pin_high?', 1, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GpioPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', Gpio[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_isPinHigh', 'value_boolean');
+            converter.addField(block, 'PIN', args[0]);
+            return block;
+        });
+
+        // backward compatibility: set_digital
+        registerLegacyHandler('set_digital', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GpioPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', Gpio[index], args[0].node);
+            } else {
+                return null;
+            }
+            if (converter.isString(args[1])) {
+                const index = DigitalValueMenuLower.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('str', DigitalValueMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_setDigitalOut', 'statement');
+            converter.addField(block, 'PIN', args[0]);
+            converter.addFieldInput(block, 'LEVEL', 'microbitMore_menu_digitalValueMenu', 'digitalValueMenu',
+                args[1], 'false');
+            return block;
+        });
+
+        // backward compatibility: set_analog
+        registerLegacyHandler('set_analog', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GpioPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', Gpio[index], args[0].node);
+            } else {
+                return null;
+            }
+            if (!converter.isNumberOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_setAnalogOut', 'statement');
+            converter.addField(block, 'PIN', args[0]);
+            converter.addNumberInput(block, 'LEVEL', 'math_number', args[1], 0);
+            return block;
+        });
+
+        // backward compatibility: set_servo
+        registerLegacyHandler('set_servo', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = GpioPin.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('int', Gpio[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            if (!converter.isNumberOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_setServo', 'statement');
+            converter.addField(block, 'PIN', args[0]);
+            converter.addNumberInput(block, 'ANGLE', 'math_number', args[1], 0);
+            return block;
+        });
+
+        // backward compatibility: play_tone
+        registerLegacyHandler('play_tone', 2, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isNumberOrBlock(args[0])) return null;
+            if (!converter.isNumberOrBlock(args[1])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_playTone', 'statement');
+            converter.addNumberInput(block, 'FREQ', 'math_number', args[0], 440);
+            converter.addNumberInput(block, 'VOL', 'math_number', args[1], 100);
+            return block;
+        });
+
+        // backward compatibility: stop_tone
+        registerLegacyHandler('stop_tone', 0, params => {
+            const {receiver} = params;
+            return converter.changeRubyExpressionBlock(receiver, 'microbitMore_stopTone', 'statement');
+        });
+
+        // backward compatibility: listen_event_on
+        registerLegacyHandler('listen_event_on', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = PinEventTypeMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', PinEventTypeMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            if (converter.isString(args[1])) {
+                const index = GpioPin.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('int', Gpio[index], args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_listenPinEventType', 'statement');
+            converter.addField(block, 'EVENT_TYPE', args[0]);
+            converter.addField(block, 'PIN', args[1]);
+            return block;
+        });
+
+        // backward compatibility: when_catch_at_pin
+        registerLegacyHandlerWithBlock('when_catch_at_pin', 2, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (converter.isString(args[0])) {
+                const index = PinEventMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', PinEventMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            if (converter.isString(args[1])) {
+                const index = GpioPin.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('int', Gpio[index], args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenPinEvent', 'hat');
+            converter.addField(block, 'EVENT', args[0]);
+            converter.addField(block, 'PIN', args[1], '0');
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: value_of
+        registerLegacyHandler('value_of', 2, params => {
+            const {receiver, args} = params;
+
+            if (converter.isString(args[0])) {
+                const index = PinEventMenuLower.indexOf(args[0].toString().toLowerCase());
+                if (index < 0) return null;
+                args[0] = new Primitive('str', PinEventMenuValue[index], args[0].node);
+            } else {
+                return null;
+            }
+
+            if (converter.isString(args[1])) {
+                const index = GpioPin.indexOf(args[1].toString().toLowerCase());
+                if (index < 0) return null;
+                args[1] = new Primitive('int', Gpio[index], args[1].node);
+            } else {
+                return null;
+            }
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getPinEventValue', 'value');
+            converter.addField(block, 'EVENT', args[0]);
+            converter.addField(block, 'PIN', args[1], '0');
+            return block;
+        });
+
+        // backward compatibility: when_data_received_from_microbit
+        registerLegacyHandlerWithBlock('when_data_received_from_microbit', 1, 0, params => {
+            const {receiver, args, rubyBlock} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_whenDataReceived', 'hat');
+            converter.addTextInput(block, 'LABEL', args[0], 'label-01');
+            converter.setParent(rubyBlock, block);
+            return block;
+        });
+
+        // backward compatibility: data
+        registerLegacyHandler('data', 0, params => {
+            const {receiver, node} = params;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'ruby_expression', 'value_boolean');
+            block.node = node;
+            converter.addInput(block, 'EXPRESSION', converter.createTextBlock(MicrobitMoreDataLegacy));
+            return block;
+        });
+
+        // backward compatibility: microbit_more.data[]
+        converter.registerOnSend(MicrobitMoreDataLegacy, '[]', 1, params => {
+            const {receiver, args} = params;
+
+            if (!converter.isStringOrBlock(args[0])) return null;
+
+            const block = converter.changeRubyExpressionBlock(receiver, 'microbitMore_getDataLabeled', 'value');
+            converter.addTextInput(block, 'LABEL', args[0], 'label-01');
+            return block;
+        });
+
+        // backward compatibility: send_data_to_microbit
+        registerLegacyHandler('send_data_to_microbit', 2, params => {
             const {receiver, args} = params;
 
             if (!converter.isStringOrBlock(args[0])) return null;

--- a/test/integration/ruby-tab/extension_microbit.test.js
+++ b/test/integration/ruby-tab/extension_microbit.test.js
@@ -34,63 +34,63 @@ describe('Ruby Tab: micro:bit extension blocks', () => {
         await loadUri(urlFor('/'));
 
         const ruby = dedent`
-            microbit.when_button_pressed("A") do
+            microbit_v1.when_button_pressed("A") do
             end
 
-            microbit.when_button_pressed("B") do
+            microbit_v1.when_button_pressed("B") do
             end
 
-            microbit.when_button_pressed("any") do
+            microbit_v1.when_button_pressed("any") do
             end
 
-            microbit.button_pressed?("A")
+            microbit_v1.button_pressed?("A")
 
-            microbit.when("moved") do
+            microbit_v1.when("moved") do
             end
 
-            microbit.when("shaken") do
+            microbit_v1.when("shaken") do
             end
 
-            microbit.when("jumped") do
+            microbit_v1.when("jumped") do
             end
 
-            microbit.display(
+            microbit_v1.display(
               ".1.1.",
               "1.1.1",
               "1...1",
               ".1.1.",
               "..1.."
             )
-            microbit.display(x)
-            microbit.display_text("Hello!")
-            microbit.clear_display
+            microbit_v1.display(x)
+            microbit_v1.display_text("Hello!")
+            microbit_v1.clear_display
 
-            microbit.when_tilted("any") do
+            microbit_v1.when_tilted("any") do
             end
 
-            microbit.when_tilted("front") do
+            microbit_v1.when_tilted("front") do
             end
 
-            microbit.when_tilted("back") do
+            microbit_v1.when_tilted("back") do
             end
 
-            microbit.when_tilted("left") do
+            microbit_v1.when_tilted("left") do
             end
 
-            microbit.when_tilted("right") do
+            microbit_v1.when_tilted("right") do
             end
 
-            microbit.tilted?("any")
+            microbit_v1.tilted?("any")
 
-            microbit.tilt_angle("front")
+            microbit_v1.tilt_angle("front")
 
-            microbit.when_pin_connected(0) do
+            microbit_v1.when_pin_connected(0) do
             end
 
-            microbit.when_pin_connected(1) do
+            microbit_v1.when_pin_connected(1) do
             end
 
-            microbit.when_pin_connected(2) do
+            microbit_v1.when_pin_connected(2) do
             end
         `;
         await expectInterconvertBetweenCodeAndRuby(ruby);
@@ -144,46 +144,46 @@ describe('Ruby Tab: micro:bit extension blocks', () => {
         `;
 
         const newRuby = dedent`
-            microbit.when_button_pressed("A") do
+            microbit_v1.when_button_pressed("A") do
             end
 
-            microbit.when_button_pressed("B") do
+            microbit_v1.when_button_pressed("B") do
             end
 
-            microbit.when_button_pressed("any") do
+            microbit_v1.when_button_pressed("any") do
             end
 
-            microbit.when("moved") do
+            microbit_v1.when("moved") do
             end
 
-            microbit.when("shaken") do
+            microbit_v1.when("shaken") do
             end
 
-            microbit.when("jumped") do
+            microbit_v1.when("jumped") do
             end
 
-            microbit.when_tilted("any") do
+            microbit_v1.when_tilted("any") do
             end
 
-            microbit.when_tilted("front") do
+            microbit_v1.when_tilted("front") do
             end
 
-            microbit.when_tilted("back") do
+            microbit_v1.when_tilted("back") do
             end
 
-            microbit.when_tilted("left") do
+            microbit_v1.when_tilted("left") do
             end
 
-            microbit.when_tilted("right") do
+            microbit_v1.when_tilted("right") do
             end
 
-            microbit.when_pin_connected(0) do
+            microbit_v1.when_pin_connected(0) do
             end
 
-            microbit.when_pin_connected(1) do
+            microbit_v1.when_pin_connected(1) do
             end
 
-            microbit.when_pin_connected(2) do
+            microbit_v1.when_pin_connected(2) do
             end
         `;
 

--- a/test/integration/ruby-tab/extension_microbit_more.test.js
+++ b/test/integration/ruby-tab/extension_microbit_more.test.js
@@ -29,184 +29,184 @@ describe('Ruby Tab: Microbit More v2 extension blocks', () => {
         await loadUri(urlFor('/'));
 
         const code = dedent`
-            microbit_more.when_microbit("connected") do
+            microbit.when_microbit("connected") do
             end
 
-            microbit_more.when_microbit("disconnected") do
+            microbit.when_microbit("disconnected") do
             end
 
-            microbit_more.when_button_is("A", "down") do
+            microbit.when_button_is("A", "down") do
             end
 
-            microbit_more.when_button_is("B", "click") do
+            microbit.when_button_is("B", "click") do
             end
 
-            microbit_more.button_pressed?("A")
+            microbit.button_pressed?("A")
 
-            microbit_more.button_pressed?("B")
+            microbit.button_pressed?("B")
 
-            microbit_more.when_pin_is("LOGO", "touched") do
+            microbit.when_pin_is("LOGO", "touched") do
             end
 
-            microbit_more.when_pin_is("P2", "tapped") do
+            microbit.when_pin_is("P2", "tapped") do
             end
 
-            microbit_more.when_pin_connected(0) do
+            microbit.when_pin_connected(0) do
             end
 
-            microbit_more.when_pin_connected(1) do
+            microbit.when_pin_connected(1) do
             end
 
-            microbit_more.when_pin_connected(2) do
+            microbit.when_pin_connected(2) do
             end
 
-            microbit_more.pin_is_touched?("LOGO")
+            microbit.pin_is_touched?("LOGO")
 
-            microbit_more.pin_is_touched?("P2")
+            microbit.pin_is_touched?("P2")
 
-            microbit_more.when("shake") do
+            microbit.when("shake") do
             end
 
-            microbit_more.when("jumped") do
+            microbit.when("jumped") do
             end
 
-            microbit_more.when("6G") do
+            microbit.when("6G") do
             end
 
-            microbit_more.when("moved") do
+            microbit.when("moved") do
             end
 
-            microbit_more.when("tilted_any") do
+            microbit.when("tilted_any") do
             end
 
-            microbit_more.when("tilted_front") do
+            microbit.when("tilted_front") do
             end
 
-            microbit_more.when_tilted("any") do
+            microbit.when_tilted("any") do
             end
 
-            microbit_more.when_tilted("front") do
+            microbit.when_tilted("front") do
             end
 
-            microbit_more.when_tilted("back") do
+            microbit.when_tilted("back") do
             end
 
-            microbit_more.when_tilted("left") do
+            microbit.when_tilted("left") do
             end
 
-            microbit_more.when_tilted("right") do
+            microbit.when_tilted("right") do
             end
 
-            microbit_more.when("tilted_back") do
+            microbit.when("tilted_back") do
             end
 
-            microbit_more.when("tilted_left") do
+            microbit.when("tilted_left") do
             end
 
-            microbit_more.when("tilted_right") do
+            microbit.when("tilted_right") do
             end
 
-            microbit_more.tilted?("any")
+            microbit.tilted?("any")
 
-            microbit_more.tilted?("front")
+            microbit.tilted?("front")
 
-            microbit_more.tilted?("back")
+            microbit.tilted?("back")
 
-            microbit_more.tilted?("left")
+            microbit.tilted?("left")
 
-            microbit_more.tilted?("right")
+            microbit.tilted?("right")
 
-            microbit_more.display_pattern(
+            microbit.display_pattern(
               ".1.1.",
               "1.1.1",
               "1...1",
               ".1.1.",
               "..1.."
             )
-            microbit_more.display_pattern(
+            microbit.display_pattern(
               "1...1",
               ".1.1.",
               "..1..",
               ".1.1.",
               "1...1"
             )
-            microbit_more.display_text_delay("Hello!", 120)
-            microbit_more.display_text_delay("Test", 60)
-            microbit_more.clear_display
+            microbit.display_text_delay("Hello!", 120)
+            microbit.display_text_delay("Test", 60)
+            microbit.clear_display
 
-            microbit_more.light_intensity
+            microbit.light_intensity
 
-            microbit_more.temperature
+            microbit.temperature
 
-            microbit_more.angle_with_north
+            microbit.angle_with_north
 
-            microbit_more.pitch
+            microbit.pitch
 
-            microbit_more.roll
+            microbit.roll
 
-            microbit_more.tilt_angle("front")
+            microbit.tilt_angle("front")
 
-            microbit_more.tilt_angle("back")
+            microbit.tilt_angle("back")
 
-            microbit_more.tilt_angle("left")
+            microbit.tilt_angle("left")
 
-            microbit_more.tilt_angle("right")
+            microbit.tilt_angle("right")
 
-            microbit_more.sound_level
+            microbit.sound_level
 
-            microbit_more.magnetic_force("absolute")
+            microbit.magnetic_force("absolute")
 
-            microbit_more.magnetic_force("x")
+            microbit.magnetic_force("x")
 
-            microbit_more.acceleration("x")
+            microbit.acceleration("x")
 
-            microbit_more.acceleration("absolute")
+            microbit.acceleration("absolute")
 
-            microbit_more.analog_value("P0")
+            microbit.analog_value("P0")
 
-            microbit_more.analog_value("P2")
+            microbit.analog_value("P2")
 
-            microbit_more.set_pin_to_input_pull("P0", "up")
-            microbit_more.set_pin_to_input_pull("P16", "down")
+            microbit.set_pin_to_input_pull("P0", "up")
+            microbit.set_pin_to_input_pull("P16", "down")
 
-            microbit_more.is_pin_high?("P0")
+            microbit.is_pin_high?("P0")
 
-            microbit_more.is_pin_high?("P16")
+            microbit.is_pin_high?("P16")
 
-            microbit_more.set_digital("P0", "Low")
-            microbit_more.set_digital("P16", "High")
-            microbit_more.set_analog("P0", 0)
-            microbit_more.set_analog("P16", 100)
-            microbit_more.set_servo("P0", 0)
-            microbit_more.set_servo("P16", 100)
-            microbit_more.play_tone(440, 100)
-            microbit_more.play_tone(220, 50)
-            microbit_more.stop_tone
-            microbit_more.listen_event_on("none", "P0")
-            microbit_more.listen_event_on("edge", "P16")
+            microbit.set_digital("P0", "Low")
+            microbit.set_digital("P16", "High")
+            microbit.set_analog("P0", 0)
+            microbit.set_analog("P16", 100)
+            microbit.set_servo("P0", 0)
+            microbit.set_servo("P16", 100)
+            microbit.play_tone(440, 100)
+            microbit.play_tone(220, 50)
+            microbit.stop_tone
+            microbit.listen_event_on("none", "P0")
+            microbit.listen_event_on("edge", "P16")
 
-            microbit_more.when_catch_at_pin("low pulse", "P0") do
+            microbit.when_catch_at_pin("low pulse", "P0") do
             end
 
-            microbit_more.when_catch_at_pin("rise", "P16") do
+            microbit.when_catch_at_pin("rise", "P16") do
             end
 
-            microbit_more.value_of("low pulse", "P0")
+            microbit.value_of("low pulse", "P0")
 
-            microbit_more.value_of("rise", "P16")
+            microbit.value_of("rise", "P16")
 
-            microbit_more.when_data_received_from_microbit("label-01") do
+            microbit.when_data_received_from_microbit("label-01") do
             end
 
-            microbit_more.when_data_received_from_microbit("label-02") do
+            microbit.when_data_received_from_microbit("label-02") do
             end
 
-            microbit_more.data["label-01"]
+            microbit.data["label-01"]
 
-            microbit_more.data["label-02"]
+            microbit.data["label-02"]
 
-            microbit_more.send_data_to_microbit("data", "label-01")
-            microbit_more.send_data_to_microbit("123456", "label-02")
+            microbit.send_data_to_microbit("data", "label-01")
+            microbit.send_data_to_microbit("123456", "label-02")
         `;
 
         await expectInterconvertBetweenCodeAndRuby(code);

--- a/test/unit/lib/ruby-generator/microbit_more.test.js
+++ b/test/unit/lib/ruby-generator/microbit_more.test.js
@@ -19,7 +19,7 @@ describe('RubyGenerator/MicrobitMore', () => {
                 }
             }
         };
-        const expected = 'microbit_more.when_pin_connected(0) do\n';
+        const expected = 'microbit.when_pin_connected(0) do\n';
         expect(RubyGenerator.microbitMore_whenPinConnected(block)).toEqual(expected);
     });
 
@@ -32,7 +32,7 @@ describe('RubyGenerator/MicrobitMore', () => {
                 }
             }
         };
-        const expected = 'microbit_more.when_tilted("any") do\n';
+        const expected = 'microbit.when_tilted("any") do\n';
         expect(RubyGenerator.microbitMore_whenTilted(block)).toEqual(expected);
     });
 
@@ -46,7 +46,7 @@ describe('RubyGenerator/MicrobitMore', () => {
             }
         };
         const result = RubyGenerator.microbitMore_isTilted(block);
-        expect(result[0]).toEqual('microbit_more.tilted?("any")');
+        expect(result[0]).toEqual('microbit.tilted?("any")');
     });
 
     test('microbitMore_getTiltAngle', () => {
@@ -59,7 +59,7 @@ describe('RubyGenerator/MicrobitMore', () => {
             }
         };
         const result = RubyGenerator.microbitMore_getTiltAngle(block);
-        expect(result[0]).toEqual('microbit_more.tilt_angle("front")');
+        expect(result[0]).toEqual('microbit.tilt_angle("front")');
     });
 
     test('microbitMore_whenGesture(MOVED)', () => {
@@ -71,7 +71,7 @@ describe('RubyGenerator/MicrobitMore', () => {
                 }
             }
         };
-        const expected = 'microbit_more.when("moved") do\n';
+        const expected = 'microbit.when("moved") do\n';
         expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
     });
 
@@ -84,7 +84,7 @@ describe('RubyGenerator/MicrobitMore', () => {
                 }
             }
         };
-        const expected = 'microbit_more.when("tilted_any") do\n';
+        const expected = 'microbit.when("tilted_any") do\n';
         expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
     });
 
@@ -97,7 +97,7 @@ describe('RubyGenerator/MicrobitMore', () => {
                 }
             }
         };
-        const expected = 'microbit_more.when("tilted_front") do\n';
+        const expected = 'microbit.when("tilted_front") do\n';
         expect(RubyGenerator.microbitMore_whenGesture(block)).toEqual(expected);
     });
 
@@ -111,7 +111,7 @@ describe('RubyGenerator/MicrobitMore', () => {
             }
         };
         RubyGenerator.valueToCode = jest.fn().mockReturnValue('"Hello!"');
-        const expected = 'microbit_more.display_text("Hello!")\n';
+        const expected = 'microbit.display_text("Hello!")\n';
         expect(RubyGenerator.microbitMore_display(block)).toEqual(expected);
     });
 
@@ -130,7 +130,7 @@ describe('RubyGenerator/MicrobitMore', () => {
         RubyGenerator.valueToCode = jest.fn()
             .mockReturnValueOnce('"Hello!"')
             .mockReturnValueOnce('120');
-        const expected = 'microbit_more.display_text_delay("Hello!", 120)\n';
+        const expected = 'microbit.display_text_delay("Hello!", 120)\n';
         expect(RubyGenerator.microbitMore_displayText(block)).toEqual(expected);
     });
 });


### PR DESCRIPTION
## Summary

- microbit more拡張機能のレシーバーを `microbit_more` から `microbit` に変更（メイン）
- microbit拡張機能のレシーバーを `microbit` から `microbit_v1` に変更（obsolete）
- 後方互換のため `microbit_more` レシーバーも引き続きサポート
- スニペットとテストを新しいレシーバー名に更新

## Implementation Details

### レシーバーマッピング

| Ruby レシーバー | 対応する拡張機能 | 備考 |
|----------------|-----------------|------|
| `microbit.xxx` | microbit more | 新しいメイン |
| `microbit_more.xxx` | microbit more | 後方互換 |
| `microbit_v1.xxx` | microbit (旧) | obsolete |

### 変更ファイル

**Ruby Generator（ブロック → Ruby）:**
- `microbit.js`: すべての `microbit.` を `microbit_v1.` に変更
- `microbit_more.js`: すべての `microbit_more.` を `microbit.` に変更

**Ruby to Blocks Converter（Ruby → ブロック）:**
- `microbit.js`: レシーバー定数を `'microbit_v1'` に変更
- `microbit_more.js`: レシーバー定数を `'microbit'` に変更 + `microbit_more` の後方互換ハンドラを追加

**スニペット:**
- `microbit-snippets.json`: `microbit.` → `microbit_v1.`
- `microbit-more-snippets.json`: `microbit_more.` → `microbit.`

## Test Coverage

- Unit tests: 351テスト全てパス
- Lint: パス

```bash
# テスト実行結果
Test Suites: 17 passed, 17 total
Tests:       351 passed, 351 total
```

## Usage Example

### 新しいレシーバー（microbit more拡張機能）

```ruby
microbit.when_button_is("A", "down") do
end

microbit.display_text_delay("Hello!", 120)
microbit.temperature
```

### 後方互換（microbit more拡張機能）

```ruby
# 以前のコードも引き続き動作
microbit_more.when_button_is("A", "down") do
end
```

### 旧microbit拡張機能（obsolete）

```ruby
microbit_v1.when_button_pressed("A") do
end

microbit_v1.display_text("Hello!")
```

Fixes smalruby/smalruby3-develop#23

🤖 Generated with [Claude Code](https://claude.ai/code)
