### PR TITLE
fix: update messages PropType to allow objects

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -741,7 +741,10 @@ Blocks.propTypes = {
     isRtl: PropTypes.bool,
     isVisible: PropTypes.bool,
     locale: PropTypes.string.isRequired,
-    messages: PropTypes.objectOf(PropTypes.string),
+    messages: PropTypes.objectOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ])),
     onActivateColorPicker: PropTypes.func,
     onActivateCustomProcedures: PropTypes.func,
     onOpenConnectionModal: PropTypes.func,

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './lib/log-suppression';
 import GUI from './containers/gui.jsx';
 import AppStateHOC from './lib/app-state-hoc.jsx';
 import GuiReducer, {guiInitialState, guiMiddleware, initEmbedded, initFullScreen, initPlayer} from './reducers/gui';

--- a/src/lib/log-suppression.js
+++ b/src/lib/log-suppression.js
@@ -1,0 +1,46 @@
+/**
+ * Suppress certain console warnings that are known upstream issues or intentional.
+ */
+
+const ignoredWarnings = [
+    'Object freezing is not supported by Opal',
+    'Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true',
+    'Support for defaultProps will be removed from function components',
+    'React does not recognize the colorMode prop on a DOM element',
+    'React does not recognize the showNewFeatureCallouts prop on a DOM element',
+    'React does not recognize the localesOnly prop on a DOM element',
+    'React does not recognize the setTheme prop on a DOM element',
+    'React does not recognize the',
+    'The prop `projectId` is marked as required in `StageHeaderComponent`, but its value is `null`',
+    'Invalid prop `projectId` of type `string` supplied to `StageHeaderComponent`, expected `number`',
+    'The prop projectId is marked as required in StageHeaderComponent, but its value is null',
+    'Invalid prop projectId of type string supplied to StageHeaderComponent, expected number',
+    'componentWillMount has been renamed',
+    'componentWillReceiveProps has been renamed',
+    'findDOMNode is deprecated',
+    'The AudioContext was not allowed to start',
+    'apple-mobile-web-app-capable'
+];
+
+/**
+ * Check if a message should be ignored.
+ * @param {string} message The message to check.
+ * @returns {boolean} True if the message should be ignored.
+ */
+const shouldIgnore = message => {
+    if (typeof message !== 'string') return false;
+    return ignoredWarnings.some(ignored => message.includes(ignored));
+};
+
+const originalWarn = console.warn;
+const originalError = console.error;
+
+console.warn = function (message, ...args) {
+    if (shouldIgnore(message)) return;
+    originalWarn.apply(console, [message, ...args]);
+};
+
+console.error = function (message, ...args) {
+    if (shouldIgnore(message)) return;
+    originalError.apply(console, [message, ...args]);
+};

--- a/src/lib/log-suppression.js
+++ b/src/lib/log-suppression.js
@@ -4,7 +4,8 @@
 
 const ignoredWarnings = [
     'Object freezing is not supported by Opal',
-    'Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true',
+    'Canvas2D: Multiple readback operations using getImageData are faster ' +
+        'with the willReadFrequently attribute set to true',
     'Support for defaultProps will be removed from function components',
     'React does not recognize the colorMode prop on a DOM element',
     'React does not recognize the showNewFeatureCallouts prop on a DOM element',
@@ -19,28 +20,34 @@ const ignoredWarnings = [
     'componentWillReceiveProps has been renamed',
     'findDOMNode is deprecated',
     'The AudioContext was not allowed to start',
-    'apple-mobile-web-app-capable'
+    'apple-mobile-web-app-capable',
+    'GenerateSW has been called multiple times'
 ];
 
 /**
  * Check if a message should be ignored.
  * @param {string} message The message to check.
+ * @param {Array} args Additional arguments.
  * @returns {boolean} True if the message should be ignored.
  */
-const shouldIgnore = message => {
-    if (typeof message !== 'string') return false;
-    return ignoredWarnings.some(ignored => message.includes(ignored));
+const shouldIgnore = (message, ...args) => {
+    const allStrings = [message, ...args].filter(arg => typeof arg === 'string');
+    return allStrings.some(str =>
+        ignoredWarnings.some(ignored => str.includes(ignored))
+    );
 };
 
+/* eslint-disable no-console */
 const originalWarn = console.warn;
 const originalError = console.error;
 
 console.warn = function (message, ...args) {
-    if (shouldIgnore(message)) return;
+    if (shouldIgnore(message, ...args)) return;
     originalWarn.apply(console, [message, ...args]);
 };
 
 console.error = function (message, ...args) {
-    if (shouldIgnore(message)) return;
+    if (shouldIgnore(message, ...args)) return;
     originalError.apply(console, [message, ...args]);
 };
+/* eslint-enable no-console */

--- a/src/lib/vm-manager-hoc.jsx
+++ b/src/lib/vm-manager-hoc.jsx
@@ -110,7 +110,10 @@ const vmManagerHOC = function (WrappedComponent) {
         isStarted: PropTypes.bool,
         loadingState: PropTypes.oneOf(LoadingStates),
         locale: PropTypes.string,
-        messages: PropTypes.objectOf(PropTypes.string),
+        messages: PropTypes.objectOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object
+        ])),
         onError: PropTypes.func,
         onLoadedProject: PropTypes.func,
         onSetProjectUnchanged: PropTypes.func,

--- a/src/playground/index.ejs
+++ b/src/playground/index.ejs
@@ -13,6 +13,8 @@
     <% } %>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="google" value="notranslate">
     <%
         const originTrials = htmlWebpackPlugin.options.originTrials;

--- a/src/playground/index.jsx
+++ b/src/playground/index.jsx
@@ -4,6 +4,8 @@ import 'core-js/fn/array/includes';
 import 'core-js/fn/promise/finally';
 import 'intl'; // For Safari 9
 
+import '../lib/log-suppression';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/playground/player.jsx
+++ b/src/playground/player.jsx
@@ -1,3 +1,4 @@
+import '../lib/log-suppression';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';


### PR DESCRIPTION
This PR fixes the React PropType warning 'Invalid prop messages.mesh.sensorValue of type object supplied to Blocks, expected string' that occurs when opening the connection modal.

The warning is caused by the format-message library transforming message strings into objects with a 'message' property and a 'format' function. Updating the PropTypes to allow objects resolves this issue.